### PR TITLE
allow html inside episode/movies overview (issue #287)

### DIFF
--- a/MediaBrowser.Controller/Providers/BaseItemXmlParser.cs
+++ b/MediaBrowser.Controller/Providers/BaseItemXmlParser.cs
@@ -145,7 +145,7 @@ namespace MediaBrowser.Controller.Providers
 
                 case "Overview":
                 case "Description":
-                    item.Overview = reader.ReadElementContentAsString();
+                    item.Overview = reader.ReadInnerXml();
                     break;
 
                 case "TagLine":


### PR DESCRIPTION
Read the overview as it is from the xml. Issue #287 

I tested it with the xml on the issue and it worked. It even rendered the format on the episode description page.
