### PR TITLE
Populate Series End Date

### DIFF
--- a/MediaBrowser.Controller/Extensions/XmlExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/XmlExtensions.cs
@@ -109,6 +109,38 @@ namespace MediaBrowser.Controller.Extensions
         }
 
         /// <summary>
+        /// Safes the get DateTime.
+        /// </summary>
+        /// <param name="doc">The doc.</param>
+        /// <param name="path">The path.</param>
+        /// <returns>System.DateTime.</returns>
+        public static DateTime? SafeGetDateTime(this XmlDocument doc, string path)
+        {
+            return SafeGetDateTime(doc, path, null);
+        }
+
+        /// <summary>
+        /// Safes the get DateTime.
+        /// </summary>
+        /// <param name="doc">The doc.</param>
+        /// <param name="path">The path.</param>
+        /// <param name="defaultDate">The default date.</param>
+        /// <returns>System.DateTime.</returns>
+        public static DateTime? SafeGetDateTime(this XmlDocument doc, string path, DateTime? defaultDate)
+        {
+            var rvalNode = doc.SelectSingleNode(path);
+
+            if (rvalNode != null)
+            {
+                var text = rvalNode.InnerText;
+                DateTime date;
+                if (DateTime.TryParse(text, out date))
+                    return date;
+            }
+            return defaultDate;
+        }
+
+        /// <summary>
         /// Safes the get string.
         /// </summary>
         /// <param name="doc">The doc.</param>

--- a/MediaBrowser.Controller/MediaBrowser.Controller.csproj
+++ b/MediaBrowser.Controller/MediaBrowser.Controller.csproj
@@ -64,6 +64,7 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedVersion.cs">

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/extensions.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/extensions.js
@@ -207,7 +207,7 @@ function parseISO8601Date(s, options) {
     // year month day    hours minutes seconds
     // dotmilliseconds
     // tzstring plusminus hours minutes
-    var re = /(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)(\.\d+)?(Z|([+-])(\d\d):(\d\d))/;
+    var re = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|([+-])(\d{2}):(\d{2}))?/;
 
     var d = s.match(re);
 


### PR DESCRIPTION
Populating missing fields for series.

Use last last date from episodes to fill the series endDate if the status is ended.
