### PR TITLE
Fixed #415 Non-Admin profile can access Dashboard

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
@@ -1120,6 +1120,7 @@ Dashboard.jQueryMobileInit();
 $(document).on('pagebeforeshow', ".page", function () {
 
     var page = $(this);
+	var pageId = this.id;
 
     var userId = Dashboard.getCurrentUserId();
     ApiClient.currentUserId(userId);
@@ -1143,6 +1144,8 @@ $(document).on('pagebeforeshow', ".page", function () {
 
             if (user.Configuration.IsAdministrator) {
                 Dashboard.ensureToolsMenu(page);
+            } else if (pageId == "dashboardPage") {
+                window.location.replace("index.html");
             }
 
             Dashboard.ensureHeader(page, user);


### PR DESCRIPTION
In site.js, in pagebeforeshow, added logic for when the current user is
not an administrator, if the page is the dashboard, to redirect to
index.html
