### PR TITLE
Swap aac encoders (again)

### DIFF
--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -528,7 +528,7 @@ namespace MediaBrowser.Api.Playback
             {
                 if (codec == AudioCodecs.Aac)
                 {
-                    return "libvo_aacenc";
+                    return "aac -strict experimental";
                 }
                 if (codec == AudioCodecs.Mp3)
                 {


### PR DESCRIPTION
Swap aac encoder in attempt to fix aac timestamp issue in hls and ts (will also allow 5.1 aac when we put it back in)
