### PR TITLE
Added auto deinterlace

### DIFF
--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -386,7 +386,7 @@ namespace MediaBrowser.Api.Playback
 
             var assSubtitleParam = string.Empty;
             var copyTsParam = string.Empty;
-            var yadif = "yadif=0:-1:0,";
+            var yadifParam = "yadif=0:-1:0,";
 
             var request = state.VideoRequest;
 
@@ -408,7 +408,7 @@ namespace MediaBrowser.Api.Playback
                 var widthParam = request.Width.Value.ToString(UsCulture);
                 var heightParam = request.Height.Value.ToString(UsCulture);
 
-                return string.Format("{4} -vf \"{0}scale=trunc({1}/2)*2:trunc({2}/2)*2{3}\"",yadif, widthParam, heightParam, assSubtitleParam, copyTsParam);
+                return string.Format("{4} -vf \"{0}scale=trunc({1}/2)*2:trunc({2}/2)*2{3}\"",yadifParam, widthParam, heightParam, assSubtitleParam, copyTsParam);
             }
 
             var isH264Output = outputVideoCodec.Equals("libx264", StringComparison.OrdinalIgnoreCase);
@@ -419,8 +419,8 @@ namespace MediaBrowser.Api.Playback
                 var widthParam = request.Width.Value.ToString(UsCulture);
 
                 return isH264Output ?
-                    string.Format("{3} -vf \"{0}scale={1}:trunc(ow/a/2)*2{2}\"",yadif, widthParam, assSubtitleParam, copyTsParam) :
-                    string.Format("{3} -vf \"{0}scale={1}:-1{2}\"",yadif, widthParam, assSubtitleParam, copyTsParam);
+                    string.Format("{3} -vf \"{0}scale={1}:trunc(ow/a/2)*2{2}\"",yadifParam, widthParam, assSubtitleParam, copyTsParam) :
+                    string.Format("{3} -vf \"{0}scale={1}:-1{2}\"",yadifParam, widthParam, assSubtitleParam, copyTsParam);
             }
 
             // If a fixed height was requested
@@ -429,8 +429,8 @@ namespace MediaBrowser.Api.Playback
                 var heightParam = request.Height.Value.ToString(UsCulture);
 
                 return isH264Output ?
-                    string.Format("{3} -vf \"{0}scale=trunc(oh*a*2)/2:{1}{2}\"",yadif, heightParam, assSubtitleParam, copyTsParam) :
-                    string.Format("{3} -vf \"{0}scale=-1:{1}{2}\"",yadif, heightParam, assSubtitleParam, copyTsParam);
+                    string.Format("{3} -vf \"{0}scale=trunc(oh*a*2)/2:{1}{2}\"",yadifParam, heightParam, assSubtitleParam, copyTsParam) :
+                    string.Format("{3} -vf \"{0}scale=-1:{1}{2}\"",yadifParam, heightParam, assSubtitleParam, copyTsParam);
             }
 
             // If a max width was requested
@@ -440,7 +440,7 @@ namespace MediaBrowser.Api.Playback
 
                 return isH264Output ?
                     string.Format("{3} -vf \"{0}scale=min(iw\\,{1}):trunc(ow/a/2)*2{2}\"", maxWidthParam, assSubtitleParam, copyTsParam) :
-                    string.Format("{3} -vf \"{0}scale=min(iw\\,{1}):-1{2}\"",yadif, maxWidthParam, assSubtitleParam, copyTsParam);
+                    string.Format("{3} -vf \"{0}scale=min(iw\\,{1}):-1{2}\"",yadifParam, maxWidthParam, assSubtitleParam, copyTsParam);
             }
 
             // If a max height was requested
@@ -449,8 +449,8 @@ namespace MediaBrowser.Api.Playback
                 var maxHeightParam = request.MaxHeight.Value.ToString(UsCulture);
 
                 return isH264Output ?
-                    string.Format("{3} -vf \"{0}scale=trunc(oh*a*2)/2:min(ih\\,{1}){2}\"",yadif, maxHeightParam, assSubtitleParam, copyTsParam) :
-                    string.Format("{3} -vf \"{0}scale=-1:min(ih\\,{1}){2}\"",yadif, maxHeightParam, assSubtitleParam, copyTsParam);
+                    string.Format("{3} -vf \"{0}scale=trunc(oh*a*2)/2:min(ih\\,{1}){2}\"",yadifParam, maxHeightParam, assSubtitleParam, copyTsParam) :
+                    string.Format("{3} -vf \"{0}scale=-1:min(ih\\,{1}){2}\"",yadifParam, maxHeightParam, assSubtitleParam, copyTsParam);
             }
 
             if (state.VideoStream == null)
@@ -473,11 +473,11 @@ namespace MediaBrowser.Api.Playback
                 var widthParam = outputSize.Width.ToString(UsCulture);
                 var heightParam = outputSize.Height.ToString(UsCulture);
 
-                return string.Format("{4} -vf \"{0}scale=trunc({1}/2)*2:trunc({2}/2)*2{3}\"",yadif, widthParam, heightParam, assSubtitleParam, copyTsParam);
+                return string.Format("{4} -vf \"{0}scale=trunc({1}/2)*2:trunc({2}/2)*2{3}\"",yadifParam, widthParam, heightParam, assSubtitleParam, copyTsParam);
             }
 
             // Otherwise use -vf scale since ffmpeg will ensure internally that the aspect ratio is preserved
-            return string.Format("{3} -vf \"{0}scale={1}:-1{2}\"",yadif, Convert.ToInt32(outputSize.Width), assSubtitleParam, copyTsParam);
+            return string.Format("{3} -vf \"{0}scale={1}:-1{2}\"",yadifParam, Convert.ToInt32(outputSize.Width), assSubtitleParam, copyTsParam);
         }
 
         /// <summary>


### PR DESCRIPTION
Will deinterlace output only if required. Mainly for live tv mpeg2 tuner cards. But will apply for all interlaced sources.
