### PR TITLE
Added IDependencyModule to allow plugins to define IoC bindings

### DIFF
--- a/MediaBrowser.Common/IApplicationHost.cs
+++ b/MediaBrowser.Common/IApplicationHost.cs
@@ -152,4 +152,15 @@ namespace MediaBrowser.Common
         /// <returns>System.Object.</returns>
         object CreateInstance(Type type);
     }
+
+    public interface IDependencyContainer
+    {
+        void RegisterSingleInstance<T>(T obj, bool manageLifetime = true)
+            where T : class;
+
+        void RegisterSingleInstance<T>(Func<T> func)
+            where T : class;
+
+        void Register(Type typeInterface, Type typeImplementation);
+    }
 }

--- a/MediaBrowser.Common/MediaBrowser.Common.csproj
+++ b/MediaBrowser.Common/MediaBrowser.Common.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Net\IWebSocketServer.cs" />
     <Compile Include="Net\MimeTypes.cs" />
     <Compile Include="Net\WebSocketConnectEventArgs.cs" />
+    <Compile Include="Plugins\IDependencyModule.cs" />
     <Compile Include="Plugins\IPlugin.cs" />
     <Compile Include="Progress\ActionableProgress.cs" />
     <Compile Include="ScheduledTasks\IScheduledTask.cs" />

--- a/MediaBrowser.Common/Plugins/IDependencyModule.cs
+++ b/MediaBrowser.Common/Plugins/IDependencyModule.cs
@@ -1,0 +1,7 @@
+﻿namespace MediaBrowser.Common.Plugins
+{
+    public interface IDependencyModule
+    {
+        void BindDependencies(IDependencyContainer container);
+    }
+}


### PR DESCRIPTION
Attempt number 2 at allowing plugins to set up their own bindings with the IoC container.

A plugin can create a class _with a parameterless constructor_ which implements `IDependencyModule`. This interface has one method, `void BindDependencies(IDependencyContainer container)` which can be used to set up bindings.

These classes are instantiated and called during `BaseApplicationHost.RegisterResources`.
