### PR TITLE
Added missing method to IHttpClient

### DIFF
--- a/MediaBrowser.Common/Net/IHttpClient.cs
+++ b/MediaBrowser.Common/Net/IHttpClient.cs
@@ -65,6 +65,14 @@ namespace MediaBrowser.Common.Net
         Task<Stream> Post(string url, Dictionary<string, string> postData, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Posts the specified options with post data
+        /// </summary>
+        /// <param name="options">The options</param>
+        /// <param name="postData">The post data</param>
+        /// <returns>Task{Stream}</returns>
+        Task<Stream> Post(HttpRequestOptions options, Dictionary<string, string> postData);
+
+        /// <summary>
         /// Posts the specified options.
         /// </summary>
         /// <param name="options">The options.</param>


### PR DESCRIPTION
I found myself needing to send post data with HttpCompression off. HttpClientManager already has the implementation but the interface was missing it
