### PR TITLE
#707 - focus search textbox when displayed

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/search.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/search.js
@@ -296,6 +296,8 @@
             var panel = getSearchPanel(page);
 
             $(panel).panel('toggle');
+
+            $('#txtSearch').focus();
         };
     }
 


### PR DESCRIPTION
Simple 1 line fix for focusing on search textbox when panel is displayed.

Please forgive me if I have done anything incorrectly. I am new to git (svn user) so this is all a bit foreign to me. :)
