### PR TITLE
Auto-Organize Copy/Move Option, Fix for Overwrite Existing File

### DIFF
--- a/MediaBrowser.Model/Configuration/AutoOrganize.cs
+++ b/MediaBrowser.Model/Configuration/AutoOrganize.cs
@@ -19,6 +19,8 @@ namespace MediaBrowser.Model.Configuration
 
         public bool DeleteEmptyFolders { get; set; }
 
+        public bool CopyOriginalFile { get; set; }
+
         public TvFileOrganizationOptions()
         {
             MinFileSizeMb = 50;
@@ -31,6 +33,8 @@ namespace MediaBrowser.Model.Configuration
             MultiEpisodeNamePattern = "%sn - %sx%0e-x%0ed - %en.%ext";
             SeasonFolderPattern = "Season %s";
             SeasonZeroFolderName = "Season 0";
+
+            CopyOriginalFile = false;
         }
     }
 }

--- a/MediaBrowser.Server.Implementations/FileOrganization/TvFolderOrganizer.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/TvFolderOrganizer.cs
@@ -61,7 +61,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
                     var organizer = new EpisodeFileOrganizer(_organizationService, _config, _fileSystem, _logger, _libraryManager,
                         _libraryMonitor, _providerManager);
 
-                    var result = await organizer.OrganizeEpisodeFile(file.FullName, options, false, cancellationToken).ConfigureAwait(false);
+                    var result = await organizer.OrganizeEpisodeFile(file.FullName, options, options.OverwriteExistingEpisodes, cancellationToken).ConfigureAwait(false);
 
                     if (result.Status == FileSortingStatus.Success)
                     {

--- a/MediaBrowser.WebDashboard/dashboard-ui/autoorganizetv.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/autoorganizetv.html
@@ -143,6 +143,14 @@
                     </div>
                     <br />
                     <ul data-role="listview" class="ulForm">
+                      <li>
+                        <label for="txtDeleteLeftOverFiles">Episode Copy/Move </label>
+                        <select name="copyOrMoveFile" id="copyOrMoveFile" data-mini="true">
+                          <option value="true">Copy</option>
+                          <option value="false">Move</option>
+                        </select>
+                        <div class="fieldDescription">Copy or move files from the "Watch Folder"</div>
+                      </li>
                         <li>
                             <input type="checkbox" id="chkOverwriteExistingEpisodes" name="chkOverwriteExistingEpisodes" />
                             <label for="chkOverwriteExistingEpisodes">Overwrite existing episodes</label>

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizetv.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizetv.js
@@ -71,6 +71,9 @@
         $('#txtMultiEpisodePattern', page).val(tvOptions.MultiEpisodeNamePattern).trigger('change');
 
         $('#txtDeleteLeftOverFiles', page).val(tvOptions.LeftOverFileExtensionsToDelete.join(';'));
+
+		$('#copyOrMoveFile', page).val(tvOptions.CopyOriginalFile.toString()).selectmenu('refresh');
+
     }
     
     $(document).on('pageinit', "#libraryFileOrganizerPage", function () {
@@ -149,6 +152,8 @@
 
                 var watchLocation = $('#txtWatchFolder', form).val();
                 tvOptions.WatchLocations = watchLocation ? [watchLocation] : [];
+
+				tvOptions.CopyOriginalFile = $('#copyOrMoveFile', form).val();
 
                 ApiClient.updateServerConfiguration(config).done(Dashboard.processServerConfigurationUpdateResult);
             });


### PR DESCRIPTION
Addition of the option in Auto-Organize to copy or move files from watch
folder.
Fix to use the Overwrite Existing File option from the config rather
than hardcoded value.
