### PR TITLE
finish implementation of opensubtitles downloader

### DIFF
--- a/MediaBrowser.Controller/Providers/ISubtitleProvider.cs
+++ b/MediaBrowser.Controller/Providers/ISubtitleProvider.cs
@@ -49,7 +49,9 @@ namespace MediaBrowser.Controller.Providers
 
         public string MediaPath { get; set; }
         public string SeriesName { get; set; }
+        public string Name { get; set; }
         public int? IndexNumber { get; set; }
         public int? ParentIndexNumber { get; set; }
+        public long ImdbId { get; set; }
     }
 }

--- a/OpenSubtitlesHandler/SubtitleTypes/SubtitleSearchParameters.cs
+++ b/OpenSubtitlesHandler/SubtitleTypes/SubtitleSearchParameters.cs
@@ -42,6 +42,17 @@ namespace OpenSubtitlesHandler
             this._query = "";
         }
 
+        public SubtitleSearchParameters(string subLanguageId, string query)
+        {
+            this.subLanguageId = subLanguageId;
+            this.movieHash = "";
+            this.movieByteSize = 0;
+            this.imdbid = "";
+            this._episode = "";
+            this._season = "";
+            this._query = query;
+        }
+
         public SubtitleSearchParameters(string subLanguageId, string query, string season, string episode)
         {
             this.subLanguageId = subLanguageId;


### PR DESCRIPTION
I added two properties to the subtitle request:
- the movie name (will be used to query subtitles based on the name)
- the imdb id of the movie (as long). just remove the "tt" from the provider ids. Is set as long because opensubtitles is using it like that. and using strings won't match (they cast it to long so it removes the leading zeros )

The only thing missing is a way to track what subtitles are downloaded in the past, so we can skip those if the user manually deletes them. Sometimes the downloaded subtitle is incorrect and we want to download a new one. The way it is currently implemented it will always download the same subtitle.
