### PR TITLE
Changed the service startup process not to wait for init

### DIFF
--- a/MediaBrowser.ServerApplication/MainStartup.cs
+++ b/MediaBrowser.ServerApplication/MainStartup.cs
@@ -226,8 +226,6 @@ namespace MediaBrowser.ServerApplication
                              ErrorModes.SEM_NOGPFAULTERRORBOX | ErrorModes.SEM_NOOPENFILEERRORBOX);
             }
 
-            SystemEvents.SessionEnding += SystemEvents_SessionEnding;
-            SystemEvents.SessionSwitch += SystemEvents_SessionSwitch;
 
             var task = _appHost.Init(initProgress);
             task = task.ContinueWith(new Action<Task>(a => _appHost.RunStartupTasks()));
@@ -239,7 +237,10 @@ namespace MediaBrowser.ServerApplication
             else
             {
                 Task.WaitAll(task);
-                
+
+                SystemEvents.SessionEnding += SystemEvents_SessionEnding;
+                SystemEvents.SessionSwitch += SystemEvents_SessionSwitch;
+   
                 HideSplashScreen();
 
                 ShowTrayIcon();


### PR DESCRIPTION
When using Windows service mode, the service fails to start quite often (I suppose it's when one has a large Library) because it's too slow.

I've changed the way startup works for service mode by not waiting for init tasks. 
