### PR TITLE
Resolve 1440px Dashboard Layout conflict

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/css/site.css
+++ b/MediaBrowser.WebDashboard/dashboard-ui/css/site.css
@@ -822,7 +822,7 @@ progress {
     }
 
         .firstDashboardHomeRightColumn .ui-collapsible-content {
-            height: 585px;
+            min-height: 585px;
         }
 }
 


### PR DESCRIPTION
When browser is exactly 1440px, unnecessary top margin added to first
right column, resulting in uneven column alignment. Positioning of right
column is also dependent on min-width 1440px in another location.
Changing to 1439px here resolves the conflict.
