### PR TITLE
Add Emby to all webpage titles

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
@@ -1283,7 +1283,7 @@ var Dashboard = {
         $('.pageTitle', $.mobile.activePage).html(title);
 
         if (title) {
-            document.title = title;
+            document.title = "Emby | " + title;
         }
     },
 


### PR DESCRIPTION
What is thought about adding "Emby | " to the page titles?

My motivation is so that I can control Emby using a Macs native media keys through [beardedspice](https://github.com/beardedspice/beardedspice/). Beardedspice can find valid tabs either by [checking their URL](https://github.com/beardedspice/beardedspice/blob/master/BeardedSpice/MediaStrategies/SoundCloudStrategy.m#L24) or [their title](https://github.com/beardedspice/beardedspice/blob/master/BeardedSpice/MediaStrategies/SubsonicStrategy.m#L24). Emby's URL could be checked (specifically checking for ":8096") but the port can change.

This change doesn't change all pages but what do you think of the idea?