### PR TITLE
Connect WebSocket connect through Reverse Proxy

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/thirdparty/apiclient/apiclient.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/thirdparty/apiclient/apiclient.js
@@ -398,7 +398,7 @@
             }
 
             var url = serverAddress.replace('http', 'ws');
-            url += "?api_key=" + accessToken;
+            url += "/?api_key=" + accessToken;
             url += "&deviceId=" + deviceId;
 
             webSocket = new WebSocket(url);


### PR DESCRIPTION
While debugging fonts and cross site stuff through reverse https:// proxy, I discovered that the WebSocket connection was unable to connect (301). Adding a slash to the base URL enabled the usage of WebSockets. I'm not sure this works for direct connections (maybe others can test?).

I couldn't find a fix in the proxy :(, this works for me. Perhaps it helps many others too. I can change my build script, but this seems the most persistent solution.

Regards,

Bauke