### PR TITLE
Handle symlinks in library folders

### DIFF
--- a/MediaBrowser.Api/EnvironmentService.cs
+++ b/MediaBrowser.Api/EnvironmentService.cs
@@ -221,7 +221,9 @@ namespace MediaBrowser.Api
         /// <returns>IEnumerable{FileSystemEntryInfo}.</returns>
         private IEnumerable<FileSystemEntryInfo> GetFileSystemEntries(GetDirectoryContents request)
         {
-            var entries = new DirectoryInfo(request.Path).EnumerateFileSystemInfos().Where(i =>
+            // using EnumerateFileSystemInfos doesn't handle reparse points (symlinks)
+            var entries = new DirectoryInfo(request.Path).EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
+                .Concat<FileSystemInfo>(new DirectoryInfo(request.Path).EnumerateFiles("*", SearchOption.TopDirectoryOnly)).Where(i =>
             {
                 if (!request.IncludeHidden && i.Attributes.HasFlag(FileAttributes.Hidden))
                 {

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -58,8 +58,9 @@ namespace MediaBrowser.Controller.Providers
                 
                 try
                 {
-                    var list = new DirectoryInfo(path)
-                        .EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly);
+                    // using EnumerateFileSystemInfos doesn't handle reparse points (symlinks)
+                    var list = new DirectoryInfo(path).EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
+                        .Concat<FileSystemInfo>(new DirectoryInfo(path).EnumerateFiles("*", SearchOption.TopDirectoryOnly));
 
                     // Seeing dupes on some users file system for some reason
                     foreach (var item in list)


### PR DESCRIPTION
Here is a first attempt at handling symlinks. I've only had a chance to test this on linux, but it should work just as well with junction points and symlinks in Windows if it didn't already. I'd almost argue that this is a bug in mono, but this fix can be used for now.

Symlinks will now work just like regular files. Emby also appears to handle broken symlinks well. Broken video files will trigger metadata download, but will refuse to play with file not found errors in the logs.


Things I haven't tested for yet:
* windows
* symlink for root folders
* symlink to parent which contains the root folder
* symlink to parent which multiple user roots (in the case of different media types)