### PR TITLE
Add support for more ssa tags in SrtParser

### DIFF
--- a/MediaBrowser.MediaEncoding/Subtitles/SrtParser.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SrtParser.cs
@@ -69,7 +69,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     }
                     subEvent.Text = string.Join(ParserValues.NewLine, multiline);
                     subEvent.Text = subEvent.Text.Replace(@"\N", ParserValues.NewLine, StringComparison.OrdinalIgnoreCase);
-                    subEvent.Text = Regex.Replace(subEvent.Text, @"\{(\\[\w]+\(?([\w\d]+,?)+\)?)+\}", string.Empty, RegexOptions.IgnoreCase);
+                    subEvent.Text = Regex.Replace(subEvent.Text, @"\{(?:\\\d?[\w.-]+(?:\([^\)]*\)|&H?[0-9A-Fa-f]+&|))+\}", string.Empty, RegexOptions.IgnoreCase);
                     subEvent.Text = Regex.Replace(subEvent.Text, "<", "&lt;", RegexOptions.IgnoreCase);
                     subEvent.Text = Regex.Replace(subEvent.Text, ">", "&gt;", RegexOptions.IgnoreCase);
                     subEvent.Text = Regex.Replace(subEvent.Text, "&lt;(\\/?(font|b|u|i|s))((\\s+(\\w|\\w[\\w\\-]*\\w)(\\s*=\\s*(?:\\\".*?\\\"|'.*?'|[^'\\\">\\s]+))?)+\\s*|\\s*)(\\/?)&gt;", "<$1$3$7>", RegexOptions.IgnoreCase);

--- a/MediaBrowser.Tests/MediaEncoding/Subtitles/TestSubtitles/unit.srt
+++ b/MediaBrowser.Tests/MediaEncoding/Subtitles/TestSubtitles/unit.srt
@@ -35,7 +35,7 @@ Unclosed but <b>supported HTML tags are left in, {\i1} SSA italics aren't
 
 9
 00:00:36,000 --> 00:00:36,999
-Multiple {\pos(142,120)\b1}SSA tags are stripped
+Multiple {\bord-3.7\clip(1,m 50 0 b 100 0 100 100 50 100 b 0 100 0 0 50 0)\pos(142,120)\t(0,500,\fscx100\fscy100)\b1\c&H000000&}SSA tags are stripped
 
 10
 00:00:37,000 --> 00:00:37,999


### PR DESCRIPTION
When failing to parse srt subtitles with ssa tags, the server will leave an http request in an opened state, never returning. At least until the request times out. _No errors are present in the log_ which is more worrisome, but the server is still functional after the user cancels their srt request (probably still functional during as well). This should probably be handled more gracefully, but left out of this merge.

The tag in question was a color change: `\c&H000000&`. I've changed the tag regex to handle more ssa tags, including color and alpha tags. The only regression would be brackets within brackets, but I don't see this as a possibility based on my quick glance of the spec.