### PR TITLE
Fix ffprobe keyframe detection on linux

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -353,7 +353,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 {
                     var text = await reader.ReadToEndAsync().ConfigureAwait(false);
 
-                    var lines = StringHelper.RegexSplit(text, "\r\n");
+                    var lines = StringHelper.RegexSplit(text, "[\r\n]+");
                     foreach (var line in lines)
                     {
                         if (string.IsNullOrWhiteSpace(line))


### PR DESCRIPTION
ffprobe output parsing implementation only works with windows style line endings.

When running the library scan on a linux machine, ffprobe uses only newlines so the regex didn't actually split the ffprobe output.

The subsequent linq code that splits each line on '=' and calls to ToDictionary() would end up throwing an ArgumentException due to duplicate keys.