### PR TITLE
Remote-Search: Allow result aggregation of multiple providers

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -727,6 +727,8 @@ namespace MediaBrowser.Providers.Manager
             where TItemType : BaseItem, new()
             where TLookupType : ItemLookupInfo
         {
+            const int maxResults = 10;
+
             // Give it a dummy path just so that it looks like a file system item
             var dummy = new TItemType
             {
@@ -755,6 +757,8 @@ namespace MediaBrowser.Providers.Manager
                 searchInfo.SearchInfo.MetadataCountryCode = ConfigurationManager.Configuration.MetadataCountryCode;
             }
 
+            var resultList = new List<RemoteSearchResult>();
+
             foreach (var provider in providers)
             {
                 try
@@ -765,7 +769,12 @@ namespace MediaBrowser.Providers.Manager
 
                     if (list.Count > 0)
                     {
-                        return list.Take(10);
+                        resultList.AddRange(list.Take(maxResults - resultList.Count));
+                    }
+
+                    if (resultList.Count >= maxResults)
+                    {
+                        return resultList;
                     }
                 }
                 catch (Exception ex)
@@ -774,8 +783,7 @@ namespace MediaBrowser.Providers.Manager
                 }
             }
 
-            // Nothing found
-            return new List<RemoteSearchResult>();
+            return resultList;
         }
 
         private async Task<IEnumerable<RemoteSearchResult>> GetSearchResults<TLookupType>(IRemoteSearchProvider<TLookupType> provider, TLookupType searchInfo,


### PR DESCRIPTION
Previously, when a remote search (without provider restriction) was
executed, the search used results from the first provider that returned
at least a single result only. Other providers were ignored.

This commit changes the behaviour in a way that all available providers
are queried until a certain number of search results has been collected.
The number is hardcoded to 10 (like it was before), but could be
parametrized in the future.