### PR TITLE
Auto-Organize: Display errors in client on server exceptions

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizelog.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizelog.js
@@ -44,7 +44,7 @@
 
                     reloadItems(page);
 
-                });
+                }).fail(onApiFailure);
             }
 
         });
@@ -60,11 +60,9 @@
             sortBy: 'SortName'
 
         }).done(function (result) {
-
             Dashboard.hideLoadingMsg();
-
             showEpisodeCorrectionPopup(page, item, result.Items);
-        });
+        }).fail(onApiFailure);
 
     }
 
@@ -129,8 +127,7 @@
 
                     reloadItems(page);
 
-                });
-
+                }).fail(onApiFailure);
             }
 
         });
@@ -160,7 +157,7 @@
 
             reloadItems(page);
 
-        });
+        }).fail(onApiFailure);
     }
 
     function reloadItems(page) {
@@ -173,7 +170,7 @@
             renderResults(page, result);
 
             Dashboard.hideLoadingMsg();
-        });
+        }).fail(onApiFailure);
 
     }
 
@@ -333,6 +330,16 @@
         }
     }
 
+    function onApiFailure(e) {
+
+        Dashboard.hideLoadingMsg();
+
+        Dashboard.alert({
+            title: Globalize.translate('AutoOrganizeError'),
+            message: e.status + ' - ' + e.statusText + '<br>' + e.getResponseHeader("X-Application-Error-Code")
+        });
+    }
+
     function onEpisodeCorrectionFormSubmit() {
         submitEpisodeForm(this);
         return false;
@@ -346,7 +353,7 @@
 
             ApiClient.clearOrganizationLog().done(function () {
                 reloadItems(page);
-            });
+            }).fail(onApiFailure);
 
         });
 

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/javascript/en-US.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/javascript/en-US.json
@@ -256,6 +256,7 @@
     "HeaderSelectWatchFolder": "Select Watch Folder",
     "HeaderSelectWatchFolderHelp": "Browse or enter the path to your watch folder. The folder must be writeable.",
     "OrganizePatternResult": "Result: {0}",
+    "AutoOrganizeError": "Error Organizing File",
     "HeaderRestart": "Restart",
     "HeaderShutdown": "Shutdown",
     "MessageConfirmRestart": "Are you sure you wish to restart Emby Server?",

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/javascript/javascript.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/javascript/javascript.json
@@ -257,6 +257,7 @@
     "HeaderSelectWatchFolder": "Select Watch Folder",
     "HeaderSelectWatchFolderHelp": "Browse or enter the path to your watch folder. The folder must be writeable.",
     "OrganizePatternResult": "Result: {0}",
+    "AutoOrganizeError": "Error Organizing File",
     "HeaderRestart": "Restart",
     "HeaderShutdown": "Shutdown",
     "MessageConfirmRestart": "Are you sure you wish to restart Emby Server?",


### PR DESCRIPTION
This is a resubmit of pull request #1197 against the dev branch:

When an exception occured on the server, the organize dialog or the confirm dialog were displayed eternally and not indication of failure was presented to the user
