### PR TITLE
Auto-Organize: PathTooLongException on source file should not break auto-organize task

### DIFF
--- a/MediaBrowser.Server.Implementations/FileOrganization/TvFolderOrganizer.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/TvFolderOrganizer.cs
@@ -35,7 +35,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
             _providerManager = providerManager;
         }
 
-        private bool IsValidVideoFile(FileInfo fileInfo)
+        private bool FilterValidVideoFile(FileInfo fileInfo)
         {
             try
             {
@@ -58,7 +58,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
 
             var eligibleFiles = watchLocations.SelectMany(GetFilesToOrganize)
                 .OrderBy(_fileSystem.GetCreationTimeUtc)
-                .Where(i => IsValidVideoFile(i) && i.Length >= minFileBytes)
+                .Where(i => FilterValidVideoFile(i) && i.Length >= minFileBytes)
                 .ToList();
 
             var processedFolders = new HashSet<string>();

--- a/MediaBrowser.Server.Implementations/FileOrganization/TvFolderOrganizer.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/TvFolderOrganizer.cs
@@ -35,7 +35,22 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
             _providerManager = providerManager;
         }
 
-        public async Task Organize(TvFileOrganizationOptions options, CancellationToken cancellationToken, IProgress<double> progress)
+        private bool IsValidVideoFile(FileInfo fileInfo)
+        {
+            try
+            {
+                var fullName = fileInfo.FullName;
+                return _libraryManager.IsVideoFile(fileInfo.FullName);
+            }
+            catch (Exception ex)
+            {
+                _logger.ErrorException("Error organizing file {0}", ex, fileInfo.Name);
+            }
+
+            return false;
+        }
+
+        public async Task Organize(AutoOrganizeOptions options, CancellationToken cancellationToken, IProgress<double> progress)
         {
             var minFileBytes = options.MinFileSizeMb * 1024 * 1024;
 
@@ -43,7 +58,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
 
             var eligibleFiles = watchLocations.SelectMany(GetFilesToOrganize)
                 .OrderBy(_fileSystem.GetCreationTimeUtc)
-                .Where(i => _libraryManager.IsVideoFile(i.FullName) && i.Length >= minFileBytes)
+                .Where(i => IsValidVideoFile(i) && i.Length >= minFileBytes)
                 .ToList();
 
             var processedFolders = new HashSet<string>();


### PR DESCRIPTION
PathTooLongException can not only occur with long destination paths but
also with too long file names of files contained in a watch folder.
Previously this condition caused the auto-organize task to break.

With this change, we still log the exception, but auto-organize
processing will continue to handle all other files.