### PR TITLE
Remote-Search: Fixed providers to return year information when searching for series

### DIFF
--- a/MediaBrowser.Providers/Omdb/OmdbItemProvider.cs
+++ b/MediaBrowser.Providers/Omdb/OmdbItemProvider.cs
@@ -133,7 +133,8 @@ namespace MediaBrowser.Providers.Omdb
                     item.SetProviderId(MetadataProviders.Imdb, result.imdbID);
 
                     int parsedYear;
-                    if (int.TryParse(result.Year, NumberStyles.Any, CultureInfo.InvariantCulture, out parsedYear))
+                    if (result.Year.Length > 0 
+                        && int.TryParse(result.Year.Substring(0, Math.Min(result.Year.Length, 4)), NumberStyles.Any, CultureInfo.InvariantCulture, out parsedYear))
                     {
                         item.ProductionYear = parsedYear;
                     }

--- a/MediaBrowser.Providers/TV/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/TvdbSeriesProvider.cs
@@ -389,6 +389,20 @@ namespace MediaBrowser.Providers.TV
                             }
                         }
 
+                        var airDateNode = node.SelectSingleNode("./FirstAired");
+                        if (airDateNode != null)
+                        {
+                            var val = airDateNode.InnerText;
+                            if (!string.IsNullOrWhiteSpace(val))
+                            {
+                                DateTime date;
+                                if (DateTime.TryParse(val, out date))
+                                {
+                                    searchResult.ProductionYear = date.Year;
+                                }
+                            }
+                        }
+
                         foreach (var title in titles)
                         {
                             if (string.Equals(title, comparableName, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
* OmdbProvider: The result often contains strings like '2010-' or
'2010-2012'. I fixed the parsing to use the first 4 digits only in these
cases
* TheMovieDb: While the search method did send appropriate queries for
different search types, it didn't differentiate for deserialization of
results. I fixed this at least for the TvResults, in order to get the
'first_air_date' property parsed.
*  TheTvdb: The parsing of the 'FirstAired' node was missing here as
well (for search results)