### PR TITLE
Fixed bug in librarybrowser.js

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/librarybrowser.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/librarybrowser.js
@@ -1643,14 +1643,6 @@
                     enableImageEnhancers: enableImageEnhancers
                 });
 
-            } else if (options.preferThumb && item.ParentThumbItemId && options.inheritThumb !== false) {
-
-                imgUrl = ApiClient.getThumbImageUrl(item.ParentThumbItemId, {
-                    type: "Thumb",
-                    maxWidth: thumbWidth,
-                    enableImageEnhancers: enableImageEnhancers
-                });
-
             } else if (options.preferThumb && item.BackdropImageTags && item.BackdropImageTags.length) {
 
                 imgUrl = ApiClient.getScaledImageUrl(item.Id, {
@@ -1661,6 +1653,14 @@
                 });
 
                 forceName = true;
+                
+            } else if (options.preferThumb && item.ParentThumbItemId && options.inheritThumb !== false) {
+
+                imgUrl = ApiClient.getThumbImageUrl(item.ParentThumbItemId, {
+                    type: "Thumb",
+                    maxWidth: thumbWidth,
+                    enableImageEnhancers: enableImageEnhancers
+                });
 
             } else if (item.ImageTags && item.ImageTags.Primary) {
 


### PR DESCRIPTION
Updated getPosterViewItemHtml to fix a bug in which a background image
was not displayed for certain movies in the "Latest Media" section of
the web interface.  More specifically, a movie that was part of a
collection (i.e. has a parent item) AND did not have a Thumb image
would not display any image.  It would attempt to get a Thumb image
from it’s parent (i.e. the collection) but would fail because the
function ApiClient.getThumbImageUrl is seriously broken.

Even if, ApiClient.getThumbImageUrl was NOT broken, it makes more sense
to show a background image for a movie than it does to show the Thumb
of a collection in which it resides.  So the precedence for these two
cases has been swapped.

The ApiClient.getThumbImageUrl function is still broken.  At the time
of this commit is it not clear what situations exercise the
‘options.preferThumb && item.ParentThumbItemId && options.inheritThumb
!== false’ case.  Since that code is broken anyhow, I assume it is not
a very important case.