### PR TITLE
Fix bug where finished item is not removed from the playlist

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/mediaplayer-video.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/mediaplayer-video.js
@@ -926,6 +926,7 @@
             currentTimeElement.html('--:--');
 
             unbindEventsForPlayback(mediaRenderer);
+            self.removeFromPlaylist(self.currentPlaylistIndex());
         };
 
         self.playVideo = function (item, mediaSource, startPosition, callback) {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/mediaplayer.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/mediaplayer.js
@@ -1572,7 +1572,7 @@
         };
 
         self.isPlaying = function () {
-            return self.playlist.length > 0;
+            return self.currentMediaRenderer ? !self.currentMediaRenderer.paused() : false;
         };
 
         self.getPlayerState = function () {


### PR DESCRIPTION
...causing the next item to fail starting.

The error that was thrown when trying to play something after a previous title had completed was
```
Cannot read property 'viblast' of null

TypeError: Cannot read property 'viblast' of null at Function.v.bg (http://app.emby.media/thirdparty/viblast/viblast.js?v=3.0.5724.6:1023:314) 
at Object.stop (http://app.emby.media/thirdparty/viblast/viblast.js?v=3.0.5724.6:7:362) 
at htmlMediaRenderer.self.stop (http://app.emby.media/scripts/htmlmediarenderer.js?v=3.0.5724.6:33:162) 
at mediaPlayer.self.stop (http://app.emby.media/scripts/all.js?v=3.0.5724.6:1919:544) 
at mediaPlayer.self.playInternal (http://app.emby.media/scripts/all.js?v=3.0.5724.6:1897:27) 
at Object.<anonymous> (http://app.emby.media/scripts/all.js?v=3.0.5724.6:1891:148) 
at j (http://app.emby.media/scripts/all.js?v=3.0.5724.6:2:26925) 
at Object.k.fireWith [as resolveWith] (http://app.emby.media/scripts/all.js?v=3.0.5724.6:2:27738) 
at Object.e.(anonymous function) [as resolve] (http://app.emby.media/scripts/all.js?v=3.0.5724.6:2:28718) 
at Object.<anonymous> (http://app.emby.media/scripts/all.js?v=3.0.5724.6:674:187)"
```

This is windows 10 with chrome 46, and IE 11 but not edge