### PR TITLE
Support for anamorphic transcoding to upscale and maintain available …

### DIFF
--- a/MediaBrowser.Server.Implementations/IO/LibraryMonitor.cs
+++ b/MediaBrowser.Server.Implementations/IO/LibraryMonitor.cs
@@ -534,7 +534,7 @@ namespace MediaBrowser.Server.Implementations.IO
 
             try
             {
-                using (_fileSystem.GetFileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+                using (_fileSystem.GetFileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 {
                     if (_updateTimer != null)
                     {


### PR DESCRIPTION
Support for anamorphic transcoding to upscale and maintain available detail rather than downscale

Fix issue in library monitor which would fill the log with errors when library folder only had readonly permissions