### PR TITLE
Support QSV decoder for LiveTV

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/MediaInfoRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/MediaInfoRequest.cs
@@ -16,6 +16,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         public VideoType VideoType { get; set; }
         public List<string> PlayableStreamFileNames { get; set; }
         public bool ExtractKeyFrameInterval { get; set; }
+        public string ProbeSizeOverride { get; set; }
 
         public MediaInfoRequest()
         {

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -136,9 +136,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
             var inputFiles = MediaEncoderHelpers.GetInputArgument(FileSystem, request.InputPath, request.Protocol, request.MountedIso, request.PlayableStreamFileNames);
 
             var extractKeyFrameInterval = request.ExtractKeyFrameInterval && request.Protocol == MediaProtocol.File && request.VideoType == VideoType.VideoFile;
+            var probeSizeArg = GetProbeSizeArgument(inputFiles, request.Protocol);
+            if (!string.IsNullOrWhiteSpace(request.ProbeSizeOverride))
+                probeSizeArg = string.Format("-probesize {0}", request.ProbeSizeOverride);
 
             return GetMediaInfoInternal(GetInputArgument(inputFiles, request.Protocol), request.InputPath, request.Protocol, extractChapters, extractKeyFrameInterval,
-                GetProbeSizeArgument(inputFiles, request.Protocol), request.MediaType == DlnaProfileType.Audio, request.VideoType, cancellationToken);
+                probeSizeArg, request.MediaType == DlnaProfileType.Audio, request.VideoType, cancellationToken);
         }
 
         /// <summary>

--- a/MediaBrowser.Model/LiveTv/LiveTvOptions.cs
+++ b/MediaBrowser.Model/LiveTv/LiveTvOptions.cs
@@ -30,10 +30,12 @@ namespace MediaBrowser.Model.LiveTv
         public string Type { get; set; }
         public bool ImportFavoritesOnly { get; set; }
         public bool IsEnabled { get; set; }
+        public string ProbeSize { get; set; }
 
         public TunerHostInfo()
         {
             IsEnabled = true;
+            ProbeSize = "5000";
         }
     }
 


### PR DESCRIPTION
ProbeSizeOverride was added because the LiveTV probe doesn't need to be that big to figure out codec.