### PR TITLE
Various improvements for file and folder browsing

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/components/directorybrowser/directorybrowser.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/components/directorybrowser/directorybrowser.js
@@ -42,7 +42,14 @@
         }
         else if (path) {
             promise = ApiClient.getDirectoryContents(path, fileOptions);
-            parentPathPromise = ApiClient.getParentPath(path);
+            parentPathPromise = ApiClient.getParentPath(path).then(function (response) {
+                if (response.status < 400) {
+                    return response.text();
+                } else {
+                    onFetchFail(request.url, response);
+                    return Promise.reject(response);
+                }
+            });
         } else {
             promise = ApiClient.getDrives();
         }
@@ -97,6 +104,10 @@
 
         var html = '';
         html += '<paper-item role="menuitem" class="' + cssClass + '" data-type="' + type + '" data-path="' + path + '">';
+
+        var icon = (type == 'File') ? 'menu' : 'folder';
+        html += '<iron-icon icon="' + icon + '" style="margin-right: 10px;" ></iron-icon>';
+
         html += '<paper-item-body>';
         html += name;
         html += '</paper-item-body>';
@@ -211,6 +222,10 @@
                 fileOptions.includeFiles = options.includeFiles;
             }
 
+            if (options.includeHidden != null) {
+                fileOptions.includeHidden = options.includeHidden;
+            }
+
             getSystemInfo().then(function (systemInfo) {
 
                 var dlg = paperDialogHelper.createDialog({
@@ -257,7 +272,7 @@
                     txtCurrentPath.val(options.path);
                 }
 
-                refreshDirectoryBrowser(editorContent, txtCurrentPath.val());
+                refreshDirectoryBrowser(editorContent, txtCurrentPath.val(), fileOptions);
 
             });
         };

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/advancedconfigurationpage.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/advancedconfigurationpage.js
@@ -108,6 +108,9 @@
 
                 picker.show({
 
+                    includeHidden: true,
+                    path: $('#txtDashboardSourcePath', page).val(),
+
                     callback: function (path) {
 
                         if (path) {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizetv.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizetv.js
@@ -139,6 +139,8 @@
 
                 picker.show({
 
+                    path: $('#txtWatchFolder', page).val(),
+
                     callback: function (path) {
 
                         if (path) {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/cinemamodeconfiguration.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/cinemamodeconfiguration.js
@@ -63,6 +63,8 @@
 
                 picker.show({
 
+                    path: $('#txtCustomIntrosPath', page).val(),
+
                     callback: function (path) {
 
                         if (path) {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/dashboardgeneral.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/dashboardgeneral.js
@@ -89,6 +89,9 @@
 
                 picker.show({
 
+                    includeHidden: true,
+                    path: $('#txtCachePath', page).val(),
+
                     callback: function (path) {
 
                         if (path) {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/dashboardhosting.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/dashboardhosting.js
@@ -66,6 +66,8 @@
 
                     includeFiles: true,
                     includeDirectories: true,
+                    includeHidden: true,
+                    path: $('#txtCertificatePath', page).val(),
 
                     callback: function (path) {
 

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/device.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/device.js
@@ -70,6 +70,8 @@
 
                 picker.show({
 
+                    path: $('#txtUploadPath', page).val(),
+
                     callback: function (path) {
 
                         if (path) {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/devicesupload.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/devicesupload.js
@@ -123,6 +123,8 @@
 
                 picker.show({
 
+                    path: $('#txtUploadPath', page).val(),
+
                     callback: function (path) {
 
                         if (path) {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/encodingsettings.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/encodingsettings.js
@@ -53,6 +53,9 @@
 
                 picker.show({
 
+                    includeHidden: true,
+                    path: $('#txtTranscodingTempPath', page).val(),
+
                     callback: function (path) {
 
                         if (path) {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/livetvsettings.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/livetvsettings.js
@@ -55,6 +55,9 @@
 
                 picker.show({
 
+                    includeHidden: true,
+                    path: $('#txtRecordingPath', page).val(),
+
                     callback: function (path) {
 
                         if (path) {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/metadataadvanced.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/metadataadvanced.js
@@ -77,6 +77,9 @@
                 
                 picker.show({
 
+                    includeHidden: true,
+                    path: $('#txtMetadataPath', page).val(),
+
                     callback: function (path) {
                         if (path) {
                             $('#txtMetadataPath', page).val(path);

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/streamingsettings.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/streamingsettings.js
@@ -35,6 +35,9 @@
 
                 picker.show({
 
+                    includeHidden: true,
+                    path: $('#txtTranscodingTempPath', page).val(),
+
                     callback: function (path) {
 
                         if (path) {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/syncsettings.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/syncsettings.js
@@ -41,6 +41,9 @@
 
                 picker.show({
 
+                    includeHidden: true,
+                    path: $('#txtSyncTempPath', page).val(),
+
                     callback: function (path) {
                         if (path) {
                             $('#txtSyncTempPath', page).val(path);


### PR DESCRIPTION
* Fixed broken parent folder API call
* Added icons to distinguish files and folders
* Modified all usages to initialize the dialog to the current value when it is displayed
* Modified some usages to also include hidden folders. Otherwise it wouldn't be possible to browse to a subfolder of the Emby installation (on Windows at least)
* Modified API behaviour to return useful results, even if the selected path is pointing to a file instead of a folder
