### PR TITLE
Improve dashboard error reporting

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/bower_components/emby-apiclient/apiclient.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/bower_components/emby-apiclient/apiclient.js
@@ -133,11 +133,19 @@
 
         function onFetchFail(url, response) {
 
+            var status = '' + response.status;
+
+            if (response.statusText)
+            {
+                status = status + ': ' + response.statusText;
+            }
+
             Events.trigger(self, 'requestfail', [
             {
                 url: url,
                 status: response.status,
-                errorCode: response.headers ? response.headers["X-Application-Error-Code"] : null
+                statusText: status,
+                errorCode: response.headers.get('X-Application-Error-Code')
             }]);
         }
 

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
@@ -92,6 +92,15 @@ var Dashboard = {
             return;
             Dashboard.hideLoadingMsg();
         }
+        else
+        {
+            // Display error messages for all other cases
+            Dashboard.hideLoadingMsg();
+            Dashboard.alert({
+                title: data.statusText,
+                message: data.errorCode
+            });
+        }
     },
 
     onPopupOpen: function () {


### PR DESCRIPTION
Previously, most errors on API calls were just swallowed without further notice.
As a result, operations that had failed to execute, often created the impression of a none-responsive or faulty UI, since there was just no visible reaction.

This commit enables display of error messages for _all_ error situations (except those few 401-errors that were already hardcoded).

We will probably identify some exceptional situations where we don't want to display an error message. 
But I think it is much better to blacklist errors here, since blacklist is small and predictable while a whitelist would be huge and never be complete.