### PR TITLE
Fix issue where shows without icons would use the last icon that was displayed

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/livetvcomponents.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/livetvcomponents.js
@@ -6,8 +6,8 @@
 
             require(['paper-fab', 'paper-item-body', 'paper-icon-item'], function () {
                 var html = '';
-
                 var index = '';
+                var imgUrl;
 
                 for (var i = 0, length = timers.length; i < length; i++) {
 
@@ -31,8 +31,8 @@
                     html += '<paper-icon-item>';
 
                     var program = timer.ProgramInfo || {};
-                    var imgUrl;
 
+                    imgUrl = null;
                     if (program.ImageTags && program.ImageTags.Primary) {
 
                         imgUrl = ApiClient.getScaledImageUrl(program.Id, {


### PR DESCRIPTION
Because of JS hoisting rules, a stale value was being used for image urls. This remedies that.

Here is an example of the bug in action:

![duplicated show icons](https://cloud.githubusercontent.com/assets/734158/12060719/bd4742ca-af43-11e5-922b-23c6cc83701e.png)
