### PR TITLE
Extended OmdbItemProvider to support series episodes

### DIFF
--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -565,7 +565,7 @@ namespace MediaBrowser.Model.Configuration
                             Type = ImageType.Thumb
                         }
                     },
-                    DisabledMetadataFetchers = new []{ "TheMovieDb" }
+                    DisabledMetadataFetchers = new []{ "The Open Movie Database", "TheMovieDb" }
                 },
 
                 new MetadataOptions(0, 1280)
@@ -586,6 +586,7 @@ namespace MediaBrowser.Model.Configuration
                             Type = ImageType.Primary
                         }
                     },
+                    DisabledMetadataFetchers = new []{ "The Open Movie Database" },
                     DisabledImageFetchers = new []{ "TheMovieDb" }
                 }
             };

--- a/MediaBrowser.Providers/MediaBrowser.Providers.csproj
+++ b/MediaBrowser.Providers/MediaBrowser.Providers.csproj
@@ -177,6 +177,7 @@
     <Compile Include="TV\MovieDbSeasonProvider.cs" />
     <Compile Include="TV\MovieDbSeriesImageProvider.cs" />
     <Compile Include="TV\MovieDbSeriesProvider.cs" />
+    <Compile Include="TV\OmdbEpisodeProvider.cs" />
     <Compile Include="TV\SeriesMetadataService.cs" />
     <Compile Include="TV\TvdbEpisodeImageProvider.cs" />
     <Compile Include="People\TvdbPersonImageProvider.cs" />

--- a/MediaBrowser.Providers/TV/OmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/OmdbEpisodeProvider.cs
@@ -1,0 +1,89 @@
+﻿using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Logging;
+using MediaBrowser.Model.Providers;
+using MediaBrowser.Model.Serialization;
+using MediaBrowser.Providers.Omdb;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Providers.TV
+{
+    class OmdbEpisodeProvider :
+            IRemoteMetadataProvider<Episode, EpisodeInfo>,
+            IHasOrder
+    {
+        private readonly IJsonSerializer _jsonSerializer;
+        private readonly IHttpClient _httpClient;
+        private OmdbItemProvider _itemProvider;
+
+        public OmdbEpisodeProvider(IJsonSerializer jsonSerializer, IHttpClient httpClient, ILogger logger, ILibraryManager libraryManager)
+        {
+            _jsonSerializer = jsonSerializer;
+            _httpClient = httpClient;
+            _itemProvider = new OmdbItemProvider(jsonSerializer, httpClient, logger, libraryManager);
+        }
+
+        public Task<IEnumerable<RemoteSearchResult>> GetSearchResults(EpisodeInfo searchInfo, CancellationToken cancellationToken)
+        {
+            return _itemProvider.GetSearchResults(searchInfo, "episode", cancellationToken);
+        }
+
+        public async Task<MetadataResult<Episode>> GetMetadata(EpisodeInfo info, CancellationToken cancellationToken)
+        {
+            var result = new MetadataResult<Episode>
+            {
+                Item = new Episode()
+            };
+
+            var imdbId = info.GetProviderId(MetadataProviders.Imdb);
+            if (string.IsNullOrWhiteSpace(imdbId))
+            {
+                imdbId = await GetEpisodeImdbId(info, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (!string.IsNullOrEmpty(imdbId))
+            {
+                result.Item.SetProviderId(MetadataProviders.Imdb, imdbId);
+                result.HasMetadata = true;
+
+                await new OmdbProvider(_jsonSerializer, _httpClient).Fetch(result.Item, imdbId, info.MetadataLanguage, info.MetadataCountryCode, cancellationToken).ConfigureAwait(false);
+            }
+
+            return result;
+        }
+
+        private async Task<string> GetEpisodeImdbId(EpisodeInfo info, CancellationToken cancellationToken)
+        {
+            var results = await GetSearchResults(info, cancellationToken).ConfigureAwait(false);
+            var first = results.FirstOrDefault();
+            return first == null ? null : first.GetProviderId(MetadataProviders.Imdb);
+        }
+
+        public int Order
+        {
+            get
+            {
+                // After TheTvDb
+                return 1;
+            }
+        }
+
+        public string Name
+        {
+            get { return "The Open Movie Database"; }
+        }
+
+        public Task<HttpResponseInfo> GetImageResponse(string url, CancellationToken cancellationToken)
+        {
+            return _itemProvider.GetImageResponse(url, cancellationToken);
+        }
+    }
+}

--- a/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
@@ -427,11 +427,18 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
             }, cancellationToken).ConfigureAwait(false);
 
             var episode = searchResults.FirstOrDefault();
+            
+            string episodeName = string.Empty;
 
             if (episode == null)
             {
-                _logger.Warn("No provider metadata found for {0} season {1} episode {2}", series.Name, seasonNumber, episodeNumber);
-                return null;
+                var msg = string.Format("No provider metadata found for {0} season {1} episode {2}", series.Name, seasonNumber, episodeNumber);
+                _logger.Warn(msg);
+                //throw new Exception(msg);
+            }
+            else
+            {
+                episodeName = episode.Name;
             }
 
             var newPath = GetSeasonFolderPath(series, seasonNumber, options);
@@ -449,7 +456,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
             // Remove additional 4 chars to prevent PathTooLongException for downloaded subtitles (eg. filename.ext.eng.srt)
             maxFilenameLength -= 4;
 
-            var episodeFileName = GetEpisodeFileName(sourcePath, series.Name, seasonNumber, episodeNumber, endingEpisodeNumber, episode.Name, options, maxFilenameLength);
+            var episodeFileName = GetEpisodeFileName(sourcePath, series.Name, seasonNumber, episodeNumber, endingEpisodeNumber, episodeName, options, maxFilenameLength);
 
             if (string.IsNullOrEmpty(episodeFileName))
             {

--- a/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
@@ -512,7 +512,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
         {
             seriesName = _fileSystem.GetValidFilename(seriesName).Trim();
 
-            if (episodeTitle == null)
+            if (string.IsNullOrEmpty(episodeTitle))
             {
                 episodeTitle = string.Empty;
             }

--- a/MediaBrowser.Server.Startup.Common/ApplicationHost.cs
+++ b/MediaBrowser.Server.Startup.Common/ApplicationHost.cs
@@ -370,6 +370,7 @@ namespace MediaBrowser.Server.Startup.Common
         {
             var migrations = new List<IVersionMigration>
             {
+                new OmdbEpisodeProviderMigration(ServerConfigurationManager),
                 new DbMigration(ServerConfigurationManager, TaskManager)
             };
 

--- a/MediaBrowser.Server.Startup.Common/MediaBrowser.Server.Startup.Common.csproj
+++ b/MediaBrowser.Server.Startup.Common/MediaBrowser.Server.Startup.Common.csproj
@@ -73,6 +73,7 @@
     <Compile Include="MbLinkShortcutHandler.cs" />
     <Compile Include="Migrations\IVersionMigration.cs" />
     <Compile Include="Migrations\DbMigration.cs" />
+    <Compile Include="Migrations\OmdbEpisodeProviderMigration.cs" />
     <Compile Include="Migrations\RenameXmlOptions.cs" />
     <Compile Include="NativeEnvironment.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/MediaBrowser.Server.Startup.Common/Migrations/OmdbEpisodeProviderMigration.cs
+++ b/MediaBrowser.Server.Startup.Common/Migrations/OmdbEpisodeProviderMigration.cs
@@ -1,0 +1,47 @@
+﻿using MediaBrowser.Controller.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Server.Startup.Common.Migrations
+{
+    class OmdbEpisodeProviderMigration : IVersionMigration
+    {
+        private readonly IServerConfigurationManager _config;
+        private const string _providerName = "The Open Movie Database";
+
+        public OmdbEpisodeProviderMigration(IServerConfigurationManager config)
+        {
+            _config = config;
+        }
+
+        public void Run()
+        {
+            var migrationKey = this.GetType().FullName;
+            var migrationKeyList = _config.Configuration.Migrations.ToList();
+
+            if (!migrationKeyList.Contains(migrationKey))
+            {
+                foreach (var metaDataOption in _config.Configuration.MetadataOptions)
+                {
+                    if (metaDataOption.ItemType == "Episode")
+                    {
+                        var disabledFetchers = metaDataOption.DisabledMetadataFetchers.ToList();
+                        if (!disabledFetchers.Contains(_providerName))
+                        {
+                            disabledFetchers.Add(_providerName);
+                            metaDataOption.DisabledMetadataFetchers = disabledFetchers.ToArray();
+                        }
+                    }
+                }
+
+                migrationKeyList.Add(migrationKey);
+                _config.Configuration.Migrations = migrationKeyList.ToArray();
+                _config.SaveConfiguration();
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
This new episode provider implementation does not bulk-download or cache
episode data. It is only meant to be a backup source for situations
where media is not recognized by that default provider.