### PR TITLE
New dashboard function for response error handling

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/bower_components/emby-apiclient/apiclient.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/bower_components/emby-apiclient/apiclient.js
@@ -137,7 +137,7 @@
             {
                 url: url,
                 status: response.status,
-                errorCode: response.headers ? response.headers["X-Application-Error-Code"] : null
+                errorCode: response.headers ? response.headers.get('X-Application-Error-Code') : null
             }]);
         }
 

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/dashboardhosting.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/dashboardhosting.js
@@ -33,7 +33,7 @@
             config.WanDdns = $('#txtDdns', form).val();
             config.CertificatePath = $('#txtCertificatePath', form).val();
 
-            ApiClient.updateServerConfiguration(config).then(Dashboard.processServerConfigurationUpdateResult);
+            ApiClient.updateServerConfiguration(config).then(Dashboard.processServerConfigurationUpdateResult, Dashboard.showResponseError);
         });
 
         // Disable default form submission

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
@@ -94,6 +94,23 @@ var Dashboard = {
         }
     },
 
+    showResponseError: function (response) {
+
+        Dashboard.hideLoadingMsg();
+
+        var status = '' + response.status;
+
+        if (response.statusText)
+        {
+            status = response.statusText;
+        }
+
+        Dashboard.alert({
+            title: status,
+            message: response.headers ? response.headers.get('X-Application-Error-Code') : null
+        });
+    },
+
     onPopupOpen: function () {
         Dashboard.popupCount = (Dashboard.popupCount || 0) + 1;
         document.body.classList.add('bodyWithPopupOpen');


### PR DESCRIPTION
This commit adds a new dashboard function for generic handling of api errors.
 A sample implementation is included for dashboardhosting.html

You closed a previous PR with comment "Based on previous discussion, can't do this."

But this PR is much different from what we discussed: It is actually NOT a general handler for arbitrary fetch exceptions. 
Instead it is just a helper function that _can_ be specified just in those cases where error display is desired - exactly that kind of behaviour that you specified in our previous discussion.

While the dashboard function is generic, it needs to be explicitly specified on each API call.

The other commit is just an example how to use it...
