### PR TITLE
Auto-Organize - Feature to remember/persist series matching in manual organization dialog: Changed to match against plain library name instead of library item GUID.

### DIFF
--- a/MediaBrowser.Controller/FileOrganization/IFileOrganizationService.cs
+++ b/MediaBrowser.Controller/FileOrganization/IFileOrganizationService.cs
@@ -78,8 +78,8 @@ namespace MediaBrowser.Controller.FileOrganization
         /// <summary>
         /// Deletes a smart match entry.
         /// </summary>
-        /// <param name="Id">Item Id.</param>
+        /// <param name="ItemName">Item name.</param>
         /// <param name="matchString">The match string to delete.</param>
-        void DeleteSmartMatchEntry(string Id, string matchString);
+        void DeleteSmartMatchEntry(string ItemName, string matchString);
     }
 }

--- a/MediaBrowser.Model/FileOrganization/SmartMatchInfo.cs
+++ b/MediaBrowser.Model/FileOrganization/SmartMatchInfo.cs
@@ -3,8 +3,8 @@ namespace MediaBrowser.Model.FileOrganization
 {
     public class SmartMatchInfo
     {
-        public string Id { get; set; }
-        public string Name { get; set; }
+        public string ItemName { get; set; }
+        public string DisplayName { get; set; }
         public FileOrganizerType OrganizerType { get; set; }
         public string[] MatchStrings { get; set; }
 

--- a/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
@@ -301,15 +301,14 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
 
         private void SaveSmartMatchString(string matchString, Series series, AutoOrganizeOptions options)
         {
-            var seriesIdString = series.Id.ToString("N");
-            SmartMatchInfo info = options.SmartMatchInfos.FirstOrDefault(i => string.Equals(i.Id, seriesIdString));
+            SmartMatchInfo info = options.SmartMatchInfos.FirstOrDefault(i => string.Equals(i.ItemName, series.Name));
 
             if (info == null)
             {
                 info = new SmartMatchInfo();
-                info.Id = series.Id.ToString("N");
+                info.ItemName = series.Name;
                 info.OrganizerType = FileOrganizerType.Episode;
-                info.Name = series.Name;
+                info.DisplayName = series.Name;
                 var list = options.SmartMatchInfos.ToList();
                 list.Add(info);
                 options.SmartMatchInfos = list.ToArray();
@@ -499,7 +498,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
                     series = _libraryManager.RootFolder
                         .GetRecursiveChildren(i => i is Series)
                         .Cast<Series>()
-                        .FirstOrDefault(i => string.Equals(i.Id.ToString("N"), info.Id));
+                        .FirstOrDefault(i => string.Equals(i.Name, info.ItemName));
                 }
             }
 

--- a/MediaBrowser.Server.Implementations/FileOrganization/FileOrganizationService.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/FileOrganizationService.cs
@@ -149,13 +149,11 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
             };
         }
 
-        public void DeleteSmartMatchEntry(string IdString, string matchString)
+        public void DeleteSmartMatchEntry(string itemName, string matchString)
         {
-            Guid Id;
-
-            if (!Guid.TryParse(IdString, out Id))
+            if (string.IsNullOrEmpty(itemName))
             {
-                throw new ArgumentNullException("Id");
+                throw new ArgumentNullException("itemName");
             }
 
             if (string.IsNullOrEmpty(matchString))
@@ -165,7 +163,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
 
             var options = GetAutoOrganizeptions();
 
-            SmartMatchInfo info = options.SmartMatchInfos.FirstOrDefault(i => string.Equals(i.Id, IdString));
+            SmartMatchInfo info = options.SmartMatchInfos.FirstOrDefault(i => string.Equals(i.ItemName, itemName));
 
             if (info != null && info.MatchStrings.Contains(matchString))
             {

--- a/MediaBrowser.WebDashboard/dashboard-ui/autoorganizelog.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/autoorganizelog.html
@@ -12,6 +12,7 @@
                 <div data-role="controlgroup" data-type="horizontal" class="localnav" data-mini="true">
                     <a href="#" data-role="button" class="ui-btn-active">${TabActivityLog}</a>
                     <a href="autoorganizetv.html" data-role="button">${TabTV}</a>
+                    <a href="autoorganizesmart.html" data-role="button">${TabSmartMatches}</a>
                 </div>
 
                 <div style="margin: -25px 0 1em; text-align: right;">
@@ -78,7 +79,7 @@
                         <div class="fieldDescription">${LabelEndingEpisodeNumberHelp}</div>
                     </div>
                     <br/>
-                    <div class="hide">
+                    <div>
                         <paper-checkbox type="checkbox" id="chkRememberCorrection">${OptionRememberOrganizeCorrection}</paper-checkbox>
                     </div>
                     <br />

--- a/MediaBrowser.WebDashboard/dashboard-ui/autoorganizetv.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/autoorganizetv.html
@@ -11,6 +11,7 @@
                 <div data-role="controlgroup" data-type="horizontal" class="localnav" data-mini="true">
                     <a href="autoorganizelog.html" data-role="button">${TabActivityLog}</a>
                     <a href="#" data-role="button" class="ui-btn-active">${TabTV}</a>
+                    <a href="autoorganizesmart.html" data-role="button">${TabSmartMatches}</a>
                 </div>
 
                 <form class="libraryFileOrganizerForm">


### PR DESCRIPTION
Auto-Organize 
- Added feature to remember/persist series matching in manual organization dialog
- Changed storage/persistance logic to match against library item name instead of internal ID (GUID).