### PR TITLE
Auto-Organize: Async operation and instant feedback UI

### DIFF
--- a/MediaBrowser.Api/Library/FileOrganizationService.cs
+++ b/MediaBrowser.Api/Library/FileOrganizationService.cs
@@ -182,11 +182,9 @@ namespace MediaBrowser.Api.Library
                 TargetFolder = request.TargetFolder
             });
 
-            // For async processing (close dialog early instead of waiting until the file has been copied)
-            //var tasks = new Task[] { task };
-            //Task.WaitAll(tasks, 8000);
-
-            Task.WaitAll(task);
+            // Async processing (close dialog early instead of waiting until the file has been copied)
+            // Wait 2s for exceptions that may occur to have them forwarded to the client for immediate error display
+            task.Wait(2000);
         }
 
         public object Get(GetSmartMatchInfos request)

--- a/MediaBrowser.Controller/FileOrganization/IFileOrganizationService.cs
+++ b/MediaBrowser.Controller/FileOrganization/IFileOrganizationService.cs
@@ -81,5 +81,21 @@ namespace MediaBrowser.Controller.FileOrganization
         /// <param name="ItemName">Item name.</param>
         /// <param name="matchString">The match string to delete.</param>
         void DeleteSmartMatchEntry(string ItemName, string matchString);
+
+        /// <summary>
+        /// Attempts to add a an item to the list of currently processed items.
+        /// </summary>
+        /// <param name="result">The result item.</param>
+        /// <param name="notifyClient">Passing true will send a websocket message to the client.</param>
+        /// <returns>True if the item was added, False if the item is already contained in the list.</returns>
+        bool AddToInProgressList(FileOrganizationResult result, bool notifyClient = false);
+
+        /// <summary>
+        /// Removes an item from the list of currently processed items.
+        /// </summary>
+        /// <param name="result">The result item.</param>
+        /// <param name="notifyClient">Passing true will send a websocket message to the client.</param>
+        /// <returns>True if the item was removed, False if the item was not contained in the list.</returns>
+        bool RemoveFromInprogressList(FileOrganizationResult result, bool notifyClient = false);
     }
 }

--- a/MediaBrowser.Model/FileOrganization/FileOrganizationResult.cs
+++ b/MediaBrowser.Model/FileOrganization/FileOrganizationResult.cs
@@ -95,6 +95,12 @@ namespace MediaBrowser.Model.FileOrganization
         /// <value>The size of the file.</value>
         public long FileSize { get; set; }
 
+        /// <summary>
+        /// Indicates if the item is currently being processed.
+        /// </summary>
+        /// <remarks>Runtime property not persisted to the store.</remarks>
+        public bool IsInProgress { get; set; }
+
         public FileOrganizationResult()
         {
             DuplicatePaths = new List<string>();

--- a/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
@@ -269,16 +269,15 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
 
             var originalExtractedSeriesString = result.ExtractedName;
 
+            try
+            {
             // Proceed to sort the file
             var newPath = await GetNewPath(sourcePath, series, seasonNumber, episodeNumber, endingEpiosdeNumber, premiereDate, options.TvOptions, cancellationToken).ConfigureAwait(false);
 
             if (string.IsNullOrEmpty(newPath))
             {
                 var msg = string.Format("Unable to sort {0} because target path could not be determined.", sourcePath);
-                result.Status = FileSortingStatus.Failure;
-                result.StatusMessage = msg;
-                _logger.Warn(msg);
-                return;
+                throw new Exception(msg);
             }
 
             _logger.Info("Sorting file {0} to new path {1}", sourcePath, newPath);
@@ -352,6 +351,14 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
                         _libraryMonitor.ReportFileSystemChangeComplete(path, true);
                     }
                 }
+            }
+            }
+            catch (Exception ex)
+            {
+                result.Status = FileSortingStatus.Failure;
+                result.StatusMessage = ex.Message;
+                _logger.Warn(ex.Message);
+                return;
             }
 
             if (rememberCorrection)
@@ -721,6 +728,11 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
 
             var pattern = endingEpisodeNumber.HasValue ? options.MultiEpisodeNamePattern : options.EpisodeNamePattern;
 
+            if (string.IsNullOrWhiteSpace(pattern))
+            {
+                throw new Exception("GetEpisodeFileName: Configured episode name pattern is empty!");
+            }
+
             var result = pattern.Replace("%sn", seriesName)
                 .Replace("%s.n", seriesName.Replace(" ", "."))
                 .Replace("%s_n", seriesName.Replace(" ", "_"))
@@ -765,8 +777,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
                 // There may be cases where reducing the title length may still not be sufficient to
                 // stay below maxLength
                 var msg = string.Format("Unable to generate an episode file name shorter than {0} characters to constrain to the max path limit", maxLength);
-                _logger.Warn(msg);
-                return string.Empty;
+                throw new Exception(msg);
             }
 
             return result;

--- a/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
@@ -208,6 +208,12 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
 
             await _organizationService.SaveResult(result, CancellationToken.None).ConfigureAwait(false);
 
+            if (result.Status != FileSortingStatus.Success)
+            {
+                // Display message in client
+                throw new Exception(result.StatusMessage);
+            }
+
             return result;
         }
 

--- a/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/EpisodeFileOrganizer.cs
@@ -622,7 +622,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
             {
                 var msg = string.Format("No provider metadata found for {0} season {1} episode {2}", series.Name, seasonNumber, episodeNumber);
                 _logger.Warn(msg);
-                return null;
+                throw new Exception(msg);
             }
 
             var episodeName = episode.Name;

--- a/MediaBrowser.Server.Startup.Common/ApplicationHost.cs
+++ b/MediaBrowser.Server.Startup.Common/ApplicationHost.cs
@@ -495,7 +495,7 @@ namespace MediaBrowser.Server.Startup.Common
             var newsService = new Implementations.News.NewsService(ApplicationPaths, JsonSerializer);
             RegisterSingleInstance<INewsService>(newsService);
 
-            var fileOrganizationService = new FileOrganizationService(TaskManager, FileOrganizationRepository, LogManager.GetLogger("FileOrganizationService"), LibraryMonitor, LibraryManager, ServerConfigurationManager, FileSystemManager, ProviderManager);
+            var fileOrganizationService = new FileOrganizationService(TaskManager, FileOrganizationRepository, LogManager.GetLogger("FileOrganizationService"), LibraryMonitor, LibraryManager, ServerConfigurationManager, FileSystemManager, ProviderManager, ServerManager);
             RegisterSingleInstance<IFileOrganizationService>(fileOrganizationService);
 
             progress.Report(15);

--- a/MediaBrowser.WebDashboard/MediaBrowser.WebDashboard.csproj
+++ b/MediaBrowser.WebDashboard/MediaBrowser.WebDashboard.csproj
@@ -149,6 +149,9 @@
     <Content Include="dashboard-ui\css\dashboard.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="dashboard-ui\css\autoorganizetable.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="dashboard-ui\css\images\logo.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/MediaBrowser.WebDashboard/dashboard-ui/autoorganizelog.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/autoorganizelog.html
@@ -1,4 +1,4 @@
-﻿<div id="libraryFileOrganizerLogPage" data-role="page" class="page type-interior organizePage withTabs" data-helpurl="https://github.com/MediaBrowser/Wiki/wiki/Auto-Organize" data-require="jqmtable,scripts/autoorganizelog,scripts/taskbutton,detailtablecss">
+﻿<div id="libraryFileOrganizerLogPage" data-role="page" class="page type-interior organizePage withTabs" data-helpurl="https://github.com/MediaBrowser/Wiki/wiki/Auto-Organize">
     <div data-role="content">
         <div class="content-primary">
 
@@ -7,26 +7,28 @@
                 </div>
 
                 <div style="float: right; position: relative; top: 15px;margin-top: -5px;display:none;" class="organizeTaskPanel">
-                    <button is="emby-button" type="button" type="button" class="btnClearLog" raised style="display: inline-block;"><iron-icon icon="clear-all"></iron-icon><span>${ButtonClear}</span></button>
-                    <button is="emby-button" type="button" type="button" class="btnOrganize" raised><iron-icon icon="check"></iron-icon><span>${ButtonOrganize}</span></button>
-                    <progress max="100" min="0" style="width:100px;display:none;" class="organizeProgress"></progress>
+                    <button is="emby-button" type="button" class="btnClearLog" raised style="display: inline-block;"><iron-icon icon="clear-all"></iron-icon><span>${ButtonClear}</span></button>
+                    <button is="emby-button" type="button" class="btnOrganize" raised><iron-icon icon="check"></iron-icon><span>${ButtonOrganize}</span></button>
+                    <progress max="100" min="0" style="width:100px;" class="organizeProgress hide"></progress>
                 </div>
                 <br />
 
                 <div style="clear: both;"></div>
             </div>
-            <table data-role="table" data-mode="reflow" class="tblOrganizationResults stripedTable ui-responsive table-stroke">
-                <thead>
-                    <tr>
-                        <th data-priority="2">${HeaderDate}</th>
-                        <th data-priority="1">${HeaderSource}</th>
-						<th data-priority="1"></th>
-                        <th data-priority="3">${HeaderDestination}</th>
-                        <th data-priority="1"></th>
-                    </tr>
-                </thead>
-                <tbody class="resultBody"></tbody>
-            </table>
+            <div class="autoorganizetable">
+                <table class="tblOrganizationResults table" style="border-collapse:collapse;">
+                    <thead>
+                        <tr>
+                            <th data-priority="1"></th>
+                            <th data-priority="2">${HeaderDate}</th>
+                            <th data-priority="1">${HeaderSource}</th>
+                            <th data-priority="3">${HeaderDestination}</th>
+                            <th data-priority="1"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="resultBody"></tbody>
+                </table>
+            </div>
             <br />
             <div style="text-align: right;vertical-align:middle;" class="legend">
                 <div style="display: inline-block; height: 10px; width: 10px; background: green;margin-right:1px;"></div>

--- a/MediaBrowser.WebDashboard/dashboard-ui/autoorganizelog.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/autoorganizelog.html
@@ -20,6 +20,7 @@
                     <tr>
                         <th data-priority="2">${HeaderDate}</th>
                         <th data-priority="1">${HeaderSource}</th>
+						<th data-priority="1"></th>
                         <th data-priority="3">${HeaderDestination}</th>
                         <th data-priority="1"></th>
                     </tr>

--- a/MediaBrowser.WebDashboard/dashboard-ui/autoorganizesmart.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/autoorganizesmart.html
@@ -1,4 +1,4 @@
-﻿<div id="libraryFileOrganizerSmartMatchPage" data-role="page" class="page type-interior organizePage withTabs" data-helpurl="https://github.com/MediaBrowser/Wiki/wiki/Auto-Organize" data-require="scripts/autoorganizesmart,paper-icon-item,paper-fab,paper-item-body">
+﻿<div id="libraryFileOrganizerSmartMatchPage" data-role="page" class="page type-interior organizePage withTabs" data-helpurl="https://github.com/MediaBrowser/Wiki/wiki/Auto-Organize">
 
     <div data-role="content">
         <div class="content-primary">

--- a/MediaBrowser.WebDashboard/dashboard-ui/autoorganizetv.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/autoorganizetv.html
@@ -1,4 +1,4 @@
-﻿<div id="libraryFileOrganizerPage" data-role="page" class="page type-interior organizePage withTabs" data-helpurl="https://github.com/MediaBrowser/Wiki/wiki/Auto-Organize" data-require="emby-collapsible,jqmtable,scripts/autoorganizetv,paper-input,paper-checkbox">
+﻿<div id="libraryFileOrganizerPage" data-role="page" class="page type-interior organizePage withTabs" data-helpurl="https://github.com/MediaBrowser/Wiki/wiki/Auto-Organize">
 
     <div data-role="content">
         <div class="content-primary">

--- a/MediaBrowser.WebDashboard/dashboard-ui/components/fileorganizer/fileorganizer.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/components/fileorganizer/fileorganizer.js
@@ -32,7 +32,7 @@
         context.querySelector('#txtSeason').value = item.ExtractedSeasonNumber;
         context.querySelector('#txtEpisode').value = item.ExtractedEpisodeNumber;
         context.querySelector('#txtEndingEpisode').value = item.ExtractedEndingEpisodeNumber;
-        //context.querySelector('.extractedName').innerHTML = item.ExtractedName;
+        context.querySelector('.extractedName').innerHTML = item.ExtractedName;
 
         extractedName = item.ExtractedName;
         extractedYear = item.ExtractedYear;

--- a/MediaBrowser.WebDashboard/dashboard-ui/css/autoorganizetable.css
+++ b/MediaBrowser.WebDashboard/dashboard-ui/css/autoorganizetable.css
@@ -1,0 +1,68 @@
+﻿.autoorganizetable > .table {
+    width: 100%;
+}
+
+    .autoorganizetable > .table > tbody > tr > td {
+        padding: 0.4em;
+    }
+
+.autoorganizetable .fileCell {
+    word-wrap: break-word;
+    word-break: break-all;
+}
+
+.autoorganizetable > .table > thead > th {
+    text-align: left;
+}
+
+.autoorganizetable tbody tr:nth-child(odd) td,
+.autoorganizetable tbody tr:nth-child(odd) th {
+    background-color: #eeeeee; /* non-RGBA fallback  */
+    background-color: rgba(0,0,0,.04);
+}
+
+
+@media screen and (max-width: 800px) {
+    .autoorganizetable > .table {
+        margin-bottom: 0;
+        background-color: transparent;
+    }
+
+    .autoorganizetable .spinnerCell {
+        display: none !important;
+    }
+
+    .autoorganizetable > .table > thead,
+    .autoorganizetable > .table > tfoot {
+        display: none;
+    }
+
+    .autoorganizetable > .table > tbody {
+        display: block;
+    }
+
+        .autoorganizetable > .table > tbody > tr {
+            display: block;
+            border: 1px solid #e0e0e0;
+            border-radius: 2px;
+            margin-bottom: 1.6rem;
+        }
+
+            .autoorganizetable > .table > tbody > tr > td {
+                background-color: #eeeeee; /* non-RGBA fallback  */
+                background-color: rgba(0,0,0,.04);
+                display: block;
+                vertical-align: middle;
+                text-align: left;
+                text-overflow: ellipsis;
+                padding: 0.4em;
+            }
+
+                .autoorganizetable > .table > tbody > tr > td[data-title]:before {
+                    content: attr(data-title);
+                    float: left;
+                    font-size: inherit;
+                    font-weight: bold;
+                    min-width: 20%;
+                }
+}

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizelog.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizelog.js
@@ -8,6 +8,19 @@
 
     var currentResult;
 
+    function parentWithClass(elem, className) {
+
+        while (!elem.classList || !elem.classList.contains(className)) {
+            elem = elem.parentNode;
+
+            if (!elem) {
+                return null;
+            }
+        }
+
+        return elem;
+    }
+
     function showStatusMessage(id) {
 
         var item = currentResult.Items.filter(function (i) {
@@ -160,14 +173,19 @@
 
             html += '<tr>';
 
-            html += '<td>';
+            html += '<td class="spinnerCell">';
+            var spinnerActive = item.IsInProgress ? 'active' : '';
+            html += '<paper-spinner class="syncSpinner"' + spinnerActive + ' style="vertical-align: middle; /">';
+            html += '</td>';
+
+            html += '<td data-title="Date">';
 
             var date = datetime.parseISO8601Date(item.Date, true);
             html += date.toLocaleDateString();
 
             html += '</td>';
 
-            html += '<td>';
+            html += '<td data-title="Source" class="fileCell">';
             var status = item.Status;
 
             if (item.IsInProgress) {
@@ -191,12 +209,7 @@
             }
             html += '</td>';
 
-            html += '<td>';
-            var spinnerActive = item.IsInProgress ? 'active' : '';
-            html += '<paper-spinner class="syncSpinner"' + spinnerActive + ' style="vertical-align: middle; /">';
-            html += '</td>';
-
-            html += '<td>';
+            html += '<td data-title="Destination" class="fileCell">';
             html += item.TargetPath || '';
             html += '</td>';
 
@@ -215,28 +228,10 @@
             return html;
         }).join('');
 
-        var elem = $('.resultBody', page).html(rows).parents('.tblOrganizationResults').table('refresh').trigger('create');
+        var resultBody = page.querySelector('.resultBody');
+        resultBody.innerHTML = rows;
 
-        $('.btnShowStatusMessage', elem).on('click', function () {
-
-            var id = this.getAttribute('data-resultid');
-
-            showStatusMessage(id);
-        });
-
-        $('.btnProcessResult', elem).on('click', function () {
-
-            var id = this.getAttribute('data-resultid');
-
-            organizeFile(page, id);
-        });
-
-        $('.btnDeleteResult', elem).on('click', function () {
-
-            var id = this.getAttribute('data-resultid');
-
-            deleteOriginalFile(page, id);
-        });
+        resultBody.addEventListener('click', handleItemClick);
 
         var pagingHtml = LibraryBrowser.getQueryPagingHtml({
             startIndex: query.StartIndex,
@@ -246,42 +241,67 @@
             updatePageSizeSetting: false
         });
 
-        $(page)[0].querySelector('.listTopPaging').innerHTML = pagingHtml;
+        var topPaging = page.querySelector('.listTopPaging');
+        topPaging.innerHTML = pagingHtml;
 
-        if (result.TotalRecordCount > query.Limit && result.TotalRecordCount > 50) {
+        var bottomPaging = page.querySelector('.listBottomPaging');
+        bottomPaging.innerHTML = pagingHtml;
 
-            $('.listBottomPaging', page).html(pagingHtml).trigger('create');
-        } else {
+        var btnNextTop = topPaging.querySelector(".btnNextPage");
+        var btnNextBottom = bottomPaging.querySelector(".btnNextPage");
+        var btnPrevTop = topPaging.querySelector(".btnPreviousPage");
+        var btnPrevBottom = bottomPaging.querySelector(".btnPreviousPage");
 
-            $('.listBottomPaging', page).empty();
-        }
-
-        $('.btnNextPage', page).on('click', function () {
-
+        btnNextTop.addEventListener('click', function () {
             query.StartIndex += query.Limit;
             reloadItems(page, true);
         });
 
-        $('.btnPreviousPage', page).on('click', function () {
+        btnNextBottom.addEventListener('click', function () {
+            query.StartIndex += query.Limit;
+            reloadItems(page, true);
+        });
 
+        btnPrevTop.addEventListener('click', function () {
             query.StartIndex -= query.Limit;
             reloadItems(page, true);
         });
 
+        btnPrevBottom.addEventListener('click', function () {
+            query.StartIndex -= query.Limit;
+            reloadItems(page, true);
+        });
+
+        var btnClearLog = page.querySelector('.btnClearLog');
+
         if (result.TotalRecordCount) {
-            $('.btnClearLog', page).show();
+            btnClearLog.classList.remove('hide');
         } else {
-            $('.btnClearLog', page).hide();
+            btnClearLog.classList.add('hide');
         }
     }
 
-    function onWebSocketMessage(e, msg) {
+    function handleItemClick(e) {
 
-        var page = $.mobile.activePage;
+        var buttonStatus = parentWithClass(e.target, 'btnShowStatusMessage');
+        if (buttonStatus) {
 
-        if ((msg.MessageType == 'ScheduledTaskEnded' && msg.Data.Key == 'AutoOrganize') || msg.MessageType == 'AutoOrganizeUpdate') {
+            var id = buttonStatus.getAttribute('data-resultid');
+            showStatusMessage(id);
+        }
 
-            reloadItems(page, false);
+        var buttonOrganize = parentWithClass(e.target, 'btnProcessResult');
+        if (buttonOrganize) {
+
+            var id = buttonOrganize.getAttribute('data-resultid');
+            organizeFile(e.view, id);
+        }
+
+        var buttonDelete = parentWithClass(e.target, 'btnDeleteResult');
+        if (buttonDelete) {
+
+            var id = buttonDelete.getAttribute('data-resultid');
+            deleteOriginalFile(e.view, id);
         }
     }
 
@@ -301,47 +321,55 @@
          }];
     }
 
-    $(document).on('pageinit', "#libraryFileOrganizerLogPage", function () {
 
-        var page = this;
+    return function (view, params) {
 
-        $('.btnClearLog', page).on('click', function () {
+        function onWebSocketMessage(e, msg) {
+
+            if ((msg.MessageType == 'ScheduledTaskEnded' && msg.Data.Key == 'AutoOrganize') || msg.MessageType == 'AutoOrganizeUpdate') {
+
+                reloadItems(view, false);
+            }
+        }
+
+        var clearButton = view.querySelector('.btnClearLog');
+        clearButton.addEventListener('click', function () {
 
             ApiClient.clearOrganizationLog().then(function () {
-                reloadItems(page, true);
+                reloadItems(view, true);
             }, Dashboard.processErrorResponse);
         });
 
-    }).on('pageshow', '#libraryFileOrganizerLogPage', function () {
+        view.addEventListener('viewshow', function (e) {
 
-        LibraryMenu.setTabs('autoorganize', 0, getTabs);
+            LibraryMenu.setTabs('autoorganize', 0, getTabs);
+            Dashboard.showLoadingMsg();
 
-        var page = this;
+            reloadItems(view, true);
 
-        reloadItems(page, true);
+            //var organizeButton = view.querySelector('.btnOrganize');
 
-        // on here
-        $('.btnOrganize', page).taskButton({
-            mode: 'on',
-            progressElem: page.querySelector('.organizeProgress'),
-            panel: $('.organizeTaskPanel', page),
-            taskKey: 'AutoOrganize'
+            $('.btnOrganize', view).taskButton({
+                mode: 'on',
+                progressElem: view.querySelector('.organizeProgress'),
+                panel: view.querySelector('.organizeTaskPanel'),
+                taskKey: 'AutoOrganize'
+            });
+
+            Events.on(ApiClient, 'websocketmessage', onWebSocketMessage);
         });
 
-        Events.on(ApiClient, 'websocketmessage', onWebSocketMessage);
+        view.addEventListener('viewhide', function (e) {
 
-    }).on('pagebeforehide', '#libraryFileOrganizerLogPage', function () {
+            currentResult = null;
 
-        var page = this;
+            //var organizeButton = view.querySelector('.btnOrganize');
 
-        currentResult = null;
+            $('.btnOrganize', page).taskButton({
+                mode: 'off'
+            });
 
-        // off here
-        $('.btnOrganize', page).taskButton({
-            mode: 'off'
+            Events.off(ApiClient, 'websocketmessage', onWebSocketMessage);
         });
-
-        Events.off(ApiClient, 'websocketmessage', onWebSocketMessage);
-    });
-
+    };
 });

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizelog.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizelog.js
@@ -1,4 +1,4 @@
-﻿define(['jQuery', 'datetime', 'paper-icon-button-light'], function ($, datetime) {
+﻿define(['jQuery', 'datetime', 'paper-icon-button-light', 'paper-spinner'], function ($, datetime) {
 
     var query = {
 
@@ -41,7 +41,7 @@
 
                     Dashboard.hideLoadingMsg();
 
-                    reloadItems(page);
+                    reloadItems(page, true);
 
                 }, Dashboard.processErrorResponse);
             });
@@ -58,7 +58,7 @@
         require(['components/fileorganizer/fileorganizer'], function (fileorganizer) {
 
             fileorganizer.show(item).then(function () {
-                reloadItems(page);
+                reloadItems(page, false);
             });
         });
     }
@@ -99,16 +99,18 @@
 
                     Dashboard.hideLoadingMsg();
 
-                    reloadItems(page);
+                    reloadItems(page, true);
 
                 }, Dashboard.processErrorResponse);
             });
         });
     }
 
-    function reloadItems(page) {
+    function reloadItems(page, showSpinner) {
 
-        Dashboard.showLoadingMsg();
+        if (showSpinner) {
+            Dashboard.showLoadingMsg();
+        }
 
         ApiClient.getFileOrganizationResults(query).then(function (result) {
 
@@ -168,7 +170,12 @@
             html += '<td>';
             var status = item.Status;
 
-            if (status == 'SkippedExisting') {
+            if (item.IsInProgress) {
+                html += '<div style="color:darkorange;">';
+                html += item.OriginalFileName;
+                html += '</div>';
+            }
+            else if (status == 'SkippedExisting') {
                 html += '<a data-resultid="' + item.Id + '" style="color:blue;" href="#" class="btnShowStatusMessage">';
                 html += item.OriginalFileName;
                 html += '</a>';
@@ -182,6 +189,11 @@
                 html += item.OriginalFileName;
                 html += '</div>';
             }
+            html += '</td>';
+
+            html += '<td>';
+            var spinnerActive = item.IsInProgress ? 'active' : '';
+            html += '<paper-spinner class="syncSpinner"' + spinnerActive + ' style="vertical-align: middle; /">';
             html += '</td>';
 
             html += '<td>';
@@ -247,13 +259,13 @@
         $('.btnNextPage', page).on('click', function () {
 
             query.StartIndex += query.Limit;
-            reloadItems(page);
+            reloadItems(page, true);
         });
 
         $('.btnPreviousPage', page).on('click', function () {
 
             query.StartIndex -= query.Limit;
-            reloadItems(page);
+            reloadItems(page, true);
         });
 
         if (result.TotalRecordCount) {
@@ -269,7 +281,7 @@
 
         if ((msg.MessageType == 'ScheduledTaskEnded' && msg.Data.Key == 'AutoOrganize') || msg.MessageType == 'AutoOrganizeUpdate') {
 
-            reloadItems(page);
+            reloadItems(page, false);
         }
     }
 
@@ -296,7 +308,7 @@
         $('.btnClearLog', page).on('click', function () {
 
             ApiClient.clearOrganizationLog().then(function () {
-                reloadItems(page);
+                reloadItems(page, true);
             }, Dashboard.processErrorResponse);
         });
 
@@ -306,7 +318,7 @@
 
         var page = this;
 
-        reloadItems(page);
+        reloadItems(page, true);
 
         // on here
         $('.btnOrganize', page).taskButton({

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizesmart.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizesmart.js
@@ -1,4 +1,4 @@
-﻿define(['jQuery'], function ($) {
+﻿define([], function () {
 
     var query = {
 
@@ -7,6 +7,19 @@
     };
 
     var currentResult;
+
+    function parentWithClass(elem, className) {
+
+        while (!elem.classList || !elem.classList.contains(className)) {
+            elem = elem.parentNode;
+
+            if (!elem) {
+                return null;
+            }
+        }
+
+        return elem;
+    }
 
     function reloadList(page) {
 
@@ -93,7 +106,8 @@
             html += "</div>";
         }
 
-        $('.divMatchInfos', page).html(html);
+        var matchInfos = page.querySelector('.divMatchInfos');
+        matchInfos.innerHTML = html;
     }
 
     function getTabs() {
@@ -112,45 +126,47 @@
          }];
     }
 
-    $(document).on('pageinit', "#libraryFileOrganizerSmartMatchPage", function () {
+    return function (view, params) {
 
-        var page = this;
+        var self = this;
 
-        $('.divMatchInfos', page).on('click', '.btnDeleteMatchEntry', function () {
+        var divInfos = view.querySelector('.divMatchInfos');
 
-            var button = this;
-            var index = parseInt(button.getAttribute('data-index'));
-            var matchIndex = parseInt(button.getAttribute('data-matchindex'));
+        divInfos.addEventListener('click', function (e) {
 
-            var info = currentResult.Items[index];
-            var entries = [
-            {
-                Name: info.ItemName,
-                Value: info.MatchStrings[matchIndex]
-            }];
+            var button = parentWithClass(e.target, 'btnDeleteMatchEntry');
 
-            ApiClient.deleteSmartMatchEntries(entries).then(function () {
+            if (button) {
 
-                reloadList(page);
+                var index = parseInt(button.getAttribute('data-index'));
+                var matchIndex = parseInt(button.getAttribute('data-matchindex'));
 
-            }, Dashboard.processErrorResponse);
+                var info = currentResult.Items[index];
+                var entries = [
+                {
+                    Name: info.ItemName,
+                    Value: info.MatchStrings[matchIndex]
+                }];
 
+                ApiClient.deleteSmartMatchEntries(entries).then(function () {
+
+                    reloadList(view);
+
+                }, Dashboard.processErrorResponse);
+            }
         });
 
-    }).on('pageshow', "#libraryFileOrganizerSmartMatchPage", function () {
+        view.addEventListener('viewshow', function (e) {
 
-        var page = this;
+            LibraryMenu.setTabs('autoorganize', 2, getTabs);
+            Dashboard.showLoadingMsg();
 
-        LibraryMenu.setTabs('autoorganize', 2, getTabs);
+            reloadList(view);
+        });
 
-        Dashboard.showLoadingMsg();
+        view.addEventListener('viewhide', function (e) {
 
-        reloadList(page);
-
-    }).on('pagebeforehide', "#libraryFileOrganizerSmartMatchPage", function () {
-
-        var page = this;
-        currentResult = null;
-    });
-
+            currentResult = null;
+        });
+    };
 });

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizetv.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizetv.js
@@ -1,13 +1,4 @@
-﻿define(['jQuery'], function ($) {
-
-    function updateSeasonPatternHelp(page, value) {
-
-        var resultValue = value.replace('%s', '1').replace('%0s', '01').replace('%00s', '001');
-
-        var replacementHtmlResult = Globalize.translate('OrganizePatternResult').replace('{0}', resultValue);
-
-        $('.seasonFolderFieldDescription', page).html(replacementHtmlResult);
-    }
+﻿define([], function () {
 
     function getEpisodeFileName(value, enableMultiEpisode) {
 
@@ -38,70 +29,50 @@
             .replace('%00e', '004');
     }
 
-    function updateEpisodePatternHelp(page, value) {
-
-        value = getEpisodeFileName(value, false);
-
-        var replacementHtmlResult = Globalize.translate('OrganizePatternResult').replace('{0}', value);
-
-        $('.episodePatternDescription', page).html(replacementHtmlResult);
-    }
-
-    function updateMultiEpisodePatternHelp(page, value) {
-
-        value = getEpisodeFileName(value, true);
-
-        var replacementHtmlResult = Globalize.translate('OrganizePatternResult').replace('{0}', value);
-
-        $('.multiEpisodePatternDescription', page).html(replacementHtmlResult);
-    }
-
-    function loadPage(page, config) {
+    function loadPage(view, config) {
 
         var tvOptions = config.TvOptions;
 
-        $('#chkEnableTvSorting', page).checked(tvOptions.IsEnabled);
-        $('#chkOverwriteExistingEpisodes', page).checked(tvOptions.OverwriteExistingEpisodes);
-        $('#chkDeleteEmptyFolders', page).checked(tvOptions.DeleteEmptyFolders);
+        view.querySelector('#chkEnableTvSorting').checked = tvOptions.IsEnabled;
+        view.querySelector('#chkOverwriteExistingEpisodes').checked = tvOptions.OverwriteExistingEpisodes;
+        view.querySelector('#chkDeleteEmptyFolders').checked = tvOptions.DeleteEmptyFolders;
 
-        $('#txtMinFileSize', page).val(tvOptions.MinFileSizeMb);
-        $('#txtSeasonFolderPattern', page).val(tvOptions.SeasonFolderPattern).trigger('change');
-        $('#txtSeasonZeroName', page).val(tvOptions.SeasonZeroFolderName);
-        $('#txtWatchFolder', page).val(tvOptions.WatchLocations[0] || '');
+        view.querySelector('#txtMinFileSize').value = tvOptions.MinFileSizeMb;
+        view.querySelector('#txtSeasonFolderPattern').value = tvOptions.SeasonFolderPattern;
+        view.querySelector('#txtSeasonZeroName').value = tvOptions.SeasonZeroFolderName;
+        view.querySelector('#txtWatchFolder').value = tvOptions.WatchLocations[0] || '';
 
-        $('#txtEpisodePattern', page).val(tvOptions.EpisodeNamePattern).trigger('change');
-        $('#txtMultiEpisodePattern', page).val(tvOptions.MultiEpisodeNamePattern).trigger('change');
+        view.querySelector('#txtEpisodePattern').value = tvOptions.EpisodeNamePattern;
+        view.querySelector('#txtMultiEpisodePattern').value = tvOptions.MultiEpisodeNamePattern;
 
-        $('#txtDeleteLeftOverFiles', page).val(tvOptions.LeftOverFileExtensionsToDelete.join(';'));
+        view.querySelector('#txtDeleteLeftOverFiles').value = tvOptions.LeftOverFileExtensionsToDelete.join(';');
 
-        $('#copyOrMoveFile', page).val(tvOptions.CopyOriginalFile.toString());
-
+        view.querySelector('#copyOrMoveFile').value = tvOptions.CopyOriginalFile.toString();
     }
 
-    function onSubmit() {
-        var form = this;
+    function onSubmit(view) {
 
         ApiClient.getNamedConfiguration('autoorganize').then(function (config) {
 
             var tvOptions = config.TvOptions;
+            
+            tvOptions.IsEnabled = view.querySelector('#chkEnableTvSorting').checked;
+            tvOptions.OverwriteExistingEpisodes = view.querySelector('#chkOverwriteExistingEpisodes').checked;
+            tvOptions.DeleteEmptyFolders = view.querySelector('#chkDeleteEmptyFolders').checked;
 
-            tvOptions.IsEnabled = $('#chkEnableTvSorting', form).checked();
-            tvOptions.OverwriteExistingEpisodes = $('#chkOverwriteExistingEpisodes', form).checked();
-            tvOptions.DeleteEmptyFolders = $('#chkDeleteEmptyFolders', form).checked();
+            tvOptions.MinFileSizeMb = view.querySelector('#txtMinFileSize').value;
+            tvOptions.SeasonFolderPattern = view.querySelector('#txtSeasonFolderPattern').value;
+            tvOptions.SeasonZeroFolderName = view.querySelector('#txtSeasonZeroName').value;
 
-            tvOptions.MinFileSizeMb = $('#txtMinFileSize', form).val();
-            tvOptions.SeasonFolderPattern = $('#txtSeasonFolderPattern', form).val();
-            tvOptions.SeasonZeroFolderName = $('#txtSeasonZeroName', form).val();
+            tvOptions.EpisodeNamePattern = view.querySelector('#txtEpisodePattern').value;
+            tvOptions.MultiEpisodeNamePattern = view.querySelector('#txtMultiEpisodePattern').value;
 
-            tvOptions.EpisodeNamePattern = $('#txtEpisodePattern', form).val();
-            tvOptions.MultiEpisodeNamePattern = $('#txtMultiEpisodePattern', form).val();
+            tvOptions.LeftOverFileExtensionsToDelete = view.querySelector('#txtDeleteLeftOverFiles').value.split(';');
 
-            tvOptions.LeftOverFileExtensionsToDelete = $('#txtDeleteLeftOverFiles', form).val().split(';');
-
-            var watchLocation = $('#txtWatchFolder', form).val();
+            var watchLocation = view.querySelector('#txtWatchFolder').value;
             tvOptions.WatchLocations = watchLocation ? [watchLocation] : [];
 
-            tvOptions.CopyOriginalFile = $('#copyOrMoveFile', form).val();
+            tvOptions.CopyOriginalFile = view.querySelector('#copyOrMoveFile').value;
 
             ApiClient.updateNamedConfiguration('autoorganize', config).then(Dashboard.processServerConfigurationUpdateResult, Dashboard.processErrorResponse);
         });
@@ -125,29 +96,40 @@
          }];
     }
 
-    $(document).on('pageinit', "#libraryFileOrganizerPage", function () {
+    return function (view, params) {
 
-        var page = this;
 
-        $('#txtSeasonFolderPattern', page).on('change keyup', function () {
+        function updateSeasonPatternHelp() {
 
-            updateSeasonPatternHelp(page, this.value);
+            var value = view.querySelector('#txtSeasonFolderPattern').value;
+            value = value.replace('%s', '1').replace('%0s', '01').replace('%00s', '001');
 
-        });
+            var replacementHtmlResult = Globalize.translate('OrganizePatternResult').replace('{0}', value);
 
-        $('#txtEpisodePattern', page).on('change keyup', function () {
+            view.querySelector('.seasonFolderFieldDescription').innerHTML = replacementHtmlResult;
+        }
 
-            updateEpisodePatternHelp(page, this.value);
+        function updateEpisodePatternHelp() {
 
-        });
+            var value = view.querySelector('#txtEpisodePattern').value;
+            var fileName = getEpisodeFileName(value, false);
 
-        $('#txtMultiEpisodePattern', page).on('change keyup', function () {
+            var replacementHtmlResult = Globalize.translate('OrganizePatternResult').replace('{0}', fileName);
 
-            updateMultiEpisodePatternHelp(page, this.value);
+            view.querySelector('.episodePatternDescription').innerHTML = replacementHtmlResult;
+        }
 
-        });
+        function updateMultiEpisodePatternHelp() {
 
-        $('#btnSelectWatchFolder', page).on("click.selectDirectory", function () {
+            var value = view.querySelector('#txtMultiEpisodePattern').value;
+            var fileName = getEpisodeFileName(value, false);
+
+            var replacementHtmlResult = Globalize.translate('OrganizePatternResult').replace('{0}', fileName);
+
+            view.querySelector('.multiEpisodePatternDescription').innerHTML = replacementHtmlResult;
+        }
+
+        function selectWatchFolder(e) {
 
             require(['directorybrowser'], function (directoryBrowser) {
 
@@ -158,28 +140,42 @@
                     callback: function (path) {
 
                         if (path) {
-                            $('#txtWatchFolder', page).val(path);
+
+                            view.querySelector('#txtWatchFolder').value = path;
                         }
                         picker.close();
                     },
-
                     header: Globalize.translate('HeaderSelectWatchFolder'),
-
                     instruction: Globalize.translate('HeaderSelectWatchFolderHelp')
                 });
             });
+        }
+
+        view.querySelector('#txtSeasonFolderPattern').addEventListener('change', updateSeasonPatternHelp);
+        view.querySelector('#txtSeasonFolderPattern').addEventListener('keyup', updateSeasonPatternHelp);
+        view.querySelector('#txtEpisodePattern').addEventListener('change', updateEpisodePatternHelp);
+        view.querySelector('#txtEpisodePattern').addEventListener('keyup', updateEpisodePatternHelp);
+        view.querySelector('#txtMultiEpisodePattern').addEventListener('change', updateMultiEpisodePatternHelp);
+        view.querySelector('#txtMultiEpisodePattern').addEventListener('keyup', updateMultiEpisodePatternHelp);
+        view.querySelector('#btnSelectWatchFolder').addEventListener('click', selectWatchFolder);
+
+        view.querySelector('.libraryFileOrganizerForm').addEventListener('submit', function (e) {
+
+            e.preventDefault();
+            onSubmit(view);
+            return false;
         });
 
-        $('.libraryFileOrganizerForm').off('submit', onSubmit).on('submit', onSubmit);
+        view.addEventListener('viewshow', function (e) {
 
-    }).on('pageshow', "#libraryFileOrganizerPage", function () {
+            LibraryMenu.setTabs('autoorganize', 1, getTabs);
 
-        var page = this;
-
-        LibraryMenu.setTabs('autoorganize', 1, getTabs);
-
-        ApiClient.getNamedConfiguration('autoorganize').then(function (config) {
-            loadPage(page, config);
+            ApiClient.getNamedConfiguration('autoorganize').then(function (config) {
+                loadPage(view, config);
+                updateSeasonPatternHelp();
+                updateEpisodePatternHelp();
+                updateMultiEpisodePatternHelp();
+            });
         });
-    });
+    };
 });

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
@@ -2182,6 +2182,7 @@ var AppInfo = {};
 
         define("livetvcss", ['css!css/livetv.css']);
         define("detailtablecss", ['css!css/detailtable.css']);
+        define("autoorganizetablecss", ['css!css/autoorganizetable.css']);
         define("tileitemcss", ['css!css/tileitem.css']);
 
         if (Dashboard.isRunningInCordova() && browserInfo.safari) {
@@ -2353,20 +2354,23 @@ var AppInfo = {};
 
         defineRoute({
             path: '/autoorganizelog.html',
-            dependencies: [],
+            dependencies: ['scripts/taskbutton', 'autoorganizetablecss'],
+            controller: 'scripts/autoorganizelog',
             roles: 'admin'
         });
 
         defineRoute({
             path: '/autoorganizesmart.html',
-            dependencies: [],
+            dependencies: ['paper-icon-item', 'paper-fab', 'paper-item-body'],
+            controller: 'scripts/autoorganizesmart',
             autoFocus: false,
             roles: 'admin'
         });
 
         defineRoute({
             path: '/autoorganizetv.html',
-            dependencies: [],
+            dependencies: ['emby-collapsible', 'jqmtable', 'paper-input', 'paper-checkbox'],
+            controller: 'scripts/autoorganizetv',
             autoFocus: false,
             roles: 'admin'
         });


### PR DESCRIPTION
**Important: This is a follow-up to PR #1506 and includes that changes**

**The relevant changes for this PR are all included in the last commit _(Auto-Organize: Async operation and instant feedback UI)_**

That commit includes changes to enable and stabilize asyncronous operations in the auto-organize area. Here are the key points:

- The auto-organize correction dialog is now closed (almost) instantly. This means that the user does not have to wait until the file copy/move operation is completed in order to continue (even with local HDs the copy/move process can take several minutes or even much longer with network destination). Thus a user will be able to initiate multiple file sorting operations without having to wait for each previous operation to complete
- This is achieved via a timeout of 2s for the web request at the server side. The purpose of this 2s period is to wait for a possbible exception. If an Exception occurs within the 2s interval, it will be instantly displayed at the client in a message box. Exceptions occuring after the 2s period are quite unlikely, but in that case the log entry will still be displayed in red color and the error message will be displayed after clicking on the item
- This commit also implements locking of files to be organized in order to prevent parallel processing of the same item. In effect, there can be 2 or more manual organization operations active even while the normal auto-organization task is running without causing any problems
- The items that are currently being processed are indicated as such in the log with an orange color and a spinner graphic
- The client display is refreshed through websocket messages
- A side effect of this is that other clients showing the auto-organize log at the same time are always up-to-date as well

Even if one would think that the waiting time to organize a single episode should be acceptable (which I think is not..): The situation will get worse when we add movie organization!
Instead of 1 or 2GB for episode we'll have to deal with files up to 10-20GB. Nobody will have enough patience to wait for this....
And: An operation with long completion time will always make users feel that an error has occured.

I think this change is crucial for the future of auto-organize ;-)
