### PR TITLE
Bugfix: Timezone-Adjustments for Premiere and Air Dates Lead to Invalid Data

### DIFF
--- a/MediaBrowser.Controller/Providers/BaseItemXmlParser.cs
+++ b/MediaBrowser.Controller/Providers/BaseItemXmlParser.cs
@@ -638,9 +638,9 @@ namespace MediaBrowser.Controller.Providers
                         {
                             DateTime airDate;
 
-                            if (DateTime.TryParseExact(firstAired, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out airDate) && airDate.Year > 1850)
+                            if (DateTime.TryParseExact(firstAired, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out airDate) && airDate.Year > 1850)
                             {
-                                item.PremiereDate = airDate.ToUniversalTime();
+                                item.PremiereDate = airDate;
                                 item.ProductionYear = airDate.Year;
                             }
                         }
@@ -657,9 +657,9 @@ namespace MediaBrowser.Controller.Providers
                         {
                             DateTime airDate;
 
-                            if (DateTime.TryParseExact(firstAired, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out airDate) && airDate.Year > 1850)
+                            if (DateTime.TryParseExact(firstAired, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out airDate) && airDate.Year > 1850)
                             {
-                                item.EndDate = airDate.ToUniversalTime();
+                                item.EndDate = airDate;
                             }
                         }
 

--- a/MediaBrowser.Providers/Movies/GenericMovieDbInfo.cs
+++ b/MediaBrowser.Providers/Movies/GenericMovieDbInfo.cs
@@ -223,7 +223,7 @@ namespace MediaBrowser.Providers.Movies
                 // These dates are always in this exact format
                 if (DateTime.TryParse(movieData.release_date, _usCulture, DateTimeStyles.None, out r))
                 {
-                    movie.PremiereDate = r.ToUniversalTime();
+                    movie.PremiereDate = r;
                     movie.ProductionYear = movie.PremiereDate.Value.Year;
                 }
             }

--- a/MediaBrowser.Providers/Movies/MovieDbProvider.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbProvider.cs
@@ -94,7 +94,7 @@ namespace MediaBrowser.Providers.Movies
                     // These dates are always in this exact format
                     if (DateTime.TryParse(obj.release_date, _usCulture, DateTimeStyles.None, out r))
                     {
-                        remoteResult.PremiereDate = r.ToUniversalTime();
+                        remoteResult.PremiereDate = r;
                         remoteResult.ProductionYear = remoteResult.PremiereDate.Value.Year;
                     }
                 }

--- a/MediaBrowser.Providers/Movies/MovieDbSearch.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbSearch.cs
@@ -173,7 +173,7 @@ namespace MediaBrowser.Providers.Movies
                             // These dates are always in this exact format
                             if (DateTime.TryParseExact(i.release_date, "yyyy-MM-dd", EnUs, DateTimeStyles.None, out r))
                             {
-                                remoteResult.PremiereDate = r.ToUniversalTime();
+                                remoteResult.PremiereDate = r;
                                 remoteResult.ProductionYear = remoteResult.PremiereDate.Value.Year;
                             }
                         }
@@ -225,7 +225,7 @@ namespace MediaBrowser.Providers.Movies
                             // These dates are always in this exact format
                             if (DateTime.TryParseExact(i.first_air_date, "yyyy-MM-dd", EnUs, DateTimeStyles.None, out r))
                             {
-                                remoteResult.PremiereDate = r.ToUniversalTime();
+                                remoteResult.PremiereDate = r;
                                 remoteResult.ProductionYear = remoteResult.PremiereDate.Value.Year;
                             }
                         }

--- a/MediaBrowser.Providers/People/MovieDbPersonProvider.cs
+++ b/MediaBrowser.Providers/People/MovieDbPersonProvider.cs
@@ -186,12 +186,12 @@ namespace MediaBrowser.Providers.People
 
                 if (DateTime.TryParseExact(info.birthday, "yyyy-MM-dd", new CultureInfo("en-US"), DateTimeStyles.None, out date))
                 {
-                    item.PremiereDate = date.ToUniversalTime();
+                    item.PremiereDate = date;
                 }
 
                 if (DateTime.TryParseExact(info.deathday, "yyyy-MM-dd", new CultureInfo("en-US"), DateTimeStyles.None, out date))
                 {
-                    item.EndDate = date.ToUniversalTime();
+                    item.EndDate = date;
                 }
 
                 item.SetProviderId(MetadataProviders.Tmdb, info.id.ToString(_usCulture));

--- a/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
@@ -525,7 +525,7 @@ namespace MediaBrowser.Providers.TV
                                             DateTime date;
                                             if (DateTime.TryParse(val, out date))
                                             {
-                                                airDate = date.ToUniversalTime();
+                                                airDate = date;
                                             }
                                         }
 

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -407,7 +407,6 @@ namespace MediaBrowser.Providers.TV
 									if (!string.IsNullOrWhiteSpace (val)) {
 										DateTime date;
 										if (DateTime.TryParse (val, out date)) {
-											date = date.ToUniversalTime ();
 
 											return date;
 										}
@@ -685,8 +684,6 @@ namespace MediaBrowser.Providers.TV
 									DateTime date;
 									if (DateTime.TryParse(val, out date))
 									{
-										date = date.ToUniversalTime();
-
 										item.PremiereDate = date;
 										item.ProductionYear = date.Year;
 									}

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
@@ -720,7 +720,7 @@ namespace MediaBrowser.Providers.TV
                                     DateTime date;
                                     if (DateTime.TryParse(val, out date))
                                     {
-                                        airDate = date.ToUniversalTime();
+                                        airDate = date;
                                     }
                                 }
 
@@ -1023,7 +1023,6 @@ namespace MediaBrowser.Providers.TV
                                     DateTime date;
                                     if (DateTime.TryParse(val, out date))
                                     {
-                                        date = date.ToUniversalTime();
 
                                         item.PremiereDate = date;
                                         item.ProductionYear = date.Year;

--- a/MediaBrowser.Server.Implementations/Library/LibraryManager.cs
+++ b/MediaBrowser.Server.Implementations/Library/LibraryManager.cs
@@ -2203,7 +2203,7 @@ namespace MediaBrowser.Server.Implementations.Library
                 {
                     if (episodeInfo.Year.HasValue && episodeInfo.Month.HasValue && episodeInfo.Day.HasValue)
                     {
-                        episode.PremiereDate = new DateTime(episodeInfo.Year.Value, episodeInfo.Month.Value, episodeInfo.Day.Value).ToUniversalTime();
+                        episode.PremiereDate = new DateTime(episodeInfo.Year.Value, episodeInfo.Month.Value, episodeInfo.Day.Value);
                     }
 
                     if (episode.PremiereDate.HasValue)


### PR DESCRIPTION
It happens like this:

- My timezone is UTC+2
- Let's look at TvdbEpisodeProvider, Line 410
- DateTime.TryParse creates a date from the string in the xml, assuming
this is a DateTime matching the local computers regional settings
- Thus, the next statement ".ToUniversalTime()" converts the datetime
(assumed as local datetime) to a UTC date
- If the parsed date is "2016-03-30 00:00" the converted date would be
"2016-03-29 22:00"
- This is happening in the provider. So if Auto-Organize or the library
is looking for 29/03 it would find the episode for 30/03 instead

All this is incorrect. PremiereDate or AirDate values should never be adjusted by timezone..