### PR TITLE
fix transcoding profiles for HDHomeRun Extend (dev)

### DIFF
--- a/MediaBrowser.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
+++ b/MediaBrowser.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
@@ -393,6 +393,7 @@ namespace MediaBrowser.Server.Implementations.LiveTv.TunerHosts.HdHomerun
                 {
                     list.Add(await GetMediaSource(info, hdhrId, "heavy").ConfigureAwait(false));
 
+                    list.Add(await GetMediaSource(info, hdhrId, "internet540").ConfigureAwait(false));
                     list.Add(await GetMediaSource(info, hdhrId, "internet480").ConfigureAwait(false));
                     list.Add(await GetMediaSource(info, hdhrId, "internet360").ConfigureAwait(false));
                     list.Add(await GetMediaSource(info, hdhrId, "internet240").ConfigureAwait(false));

--- a/MediaBrowser.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
+++ b/MediaBrowser.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
@@ -263,18 +263,10 @@ namespace MediaBrowser.Server.Implementations.LiveTv.TunerHosts.HdHomerun
                 videoCodec = "h264";
                 videoBitrate = 15000000;
             }
-            else if (string.Equals(profile, "internet720", StringComparison.OrdinalIgnoreCase))
-            {
-                width = 1280;
-                height = 720;
-                isInterlaced = false;
-                videoCodec = "h264";
-                videoBitrate = 8000000;
-            }
             else if (string.Equals(profile, "internet540", StringComparison.OrdinalIgnoreCase))
             {
-                width = 1280;
-                height = 720;
+                width = 960;
+                height = 546;
                 isInterlaced = false;
                 videoCodec = "h264";
                 videoBitrate = 2500000;


### PR DESCRIPTION
Use the correct resolution (960x548) for the internet540 profile.
Actually advertise the internet540 profile.
Remove the obsolete internet720 profile, which is no longer supported on current firmware.