### PR TITLE
allow disabling of hardware transcoding on HDTC-2US (dev)

### DIFF
--- a/MediaBrowser.Model/LiveTv/LiveTvOptions.cs
+++ b/MediaBrowser.Model/LiveTv/LiveTvOptions.cs
@@ -31,6 +31,7 @@ namespace MediaBrowser.Model.LiveTv
         public string Type { get; set; }
         public string DeviceId { get; set; }
         public bool ImportFavoritesOnly { get; set; }
+        public bool AllowHWTranscoding { get; set; }
         public bool IsEnabled { get; set; }
         public string M3UUrl { get; set; }
         public string InfoUrl { get; set; }
@@ -47,6 +48,7 @@ namespace MediaBrowser.Model.LiveTv
         public TunerHostInfo()
         {
             IsEnabled = true;
+            AllowHWTranscoding = true;
         }
     }
 

--- a/MediaBrowser.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
+++ b/MediaBrowser.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
@@ -397,7 +397,7 @@ namespace MediaBrowser.Server.Implementations.LiveTv.TunerHosts.HdHomerun
                 string model = await GetModelInfo(info, cancellationToken).ConfigureAwait(false);
                 model = model ?? string.Empty;
 
-                if (model.IndexOf("hdtc", StringComparison.OrdinalIgnoreCase) != -1)
+                if (info.AllowHWTranscoding && (model.IndexOf("hdtc", StringComparison.OrdinalIgnoreCase) != -1))
                 {
                     list.Add(await GetMediaSource(info, hdhrId, "heavy").ConfigureAwait(false));
 

--- a/MediaBrowser.WebDashboard/dashboard-ui/livetvtunerprovider-hdhomerun.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/livetvtunerprovider-hdhomerun.html
@@ -22,6 +22,11 @@
                             <paper-checkbox class="chkFavorite">${LabelImportOnlyFavoriteChannels}</paper-checkbox>
                             <div class="fieldDescription paperCheckboxFieldDescription">${ImportFavoriteChannelsHelp}</div>
                         </div>
+                        <div>
+                            <br />
+                            <paper-checkbox class="chkTranscode">${LabelAllowHWTranscoding}</paper-checkbox>
+                            <div class="fieldDescription paperCheckboxFieldDescription">${AllowHWTranscodingHelp}</div>
+                        </div>
                         <br />
                         <div>
                             <button type="submit" data-role="none" class="clearButton">

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/livetvtunerprovider-hdhomerun.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/livetvtunerprovider-hdhomerun.js
@@ -14,6 +14,7 @@
 
                 page.querySelector('.txtDevicePath').value = info.Url || '';
                 page.querySelector('.chkFavorite').checked = info.ImportFavoritesOnly;
+                page.querySelector('.chkTranscode').checked = info.AllowHWTranscoding;
                 page.querySelector('.chkEnabled').checked = info.IsEnabled;
 
             });
@@ -30,6 +31,7 @@
             Type: 'hdhomerun',
             Url: page.querySelector('.txtDevicePath').value,
             ImportFavoritesOnly: page.querySelector('.chkFavorite').checked,
+            AllowHWTranscoding: page.querySelector('.chkTranscode').checked,
             IsEnabled: page.querySelector('.chkEnabled').checked,
             DataVersion: 1
         };

--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/en-US.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/en-US.json
@@ -1443,6 +1443,8 @@
   "MessageTunerDeviceNotListed": "Is your tuner device not listed? Try installing an external service provider for more Live TV options.",
   "LabelImportOnlyFavoriteChannels": "Restrict to channels marked as favorite",
   "ImportFavoriteChannelsHelp": "If enabled, only channels that are marked as favorite on the tuner device will be imported.",
+  "LabelAllowHWTranscoding": "Allow hardware transcoding",
+  "AllowHWTranscodingHelp": "If enabled, allow the tuner to transcode streams in hardware.",
   "ButtonRepeat": "Repeat",
   "LabelEnableThisTuner": "Enable this tuner",
   "LabelEnableThisTunerHelp": "Uncheck to prevent importing channels from this tuner.",


### PR DESCRIPTION
This change adds a checkbox on the tuner configuration page that allows the hardware transcoding functionality of the HDHomeRun Extend (HDTC-2US) to be disabled.