### PR TITLE
Dashboard method for response error handling

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizelog.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizelog.js
@@ -43,7 +43,7 @@
 
                     reloadItems(page);
 
-                }, onApiFailure);
+                }, Dashboard.processErrorResponse);
             });
         });
     }
@@ -101,7 +101,7 @@
 
                     reloadItems(page);
 
-                }, onApiFailure);
+                }, Dashboard.processErrorResponse);
             });
         });
     }
@@ -116,7 +116,7 @@
             renderResults(page, result);
 
             Dashboard.hideLoadingMsg();
-        }, onApiFailure);
+        }, Dashboard.processErrorResponse);
     }
 
     function getStatusText(item, enhance) {
@@ -273,26 +273,6 @@
         }
     }
 
-    function onApiFailure(e) {
-
-        Dashboard.hideLoadingMsg();
-
-        if (e.status == 0) {
-
-            Dashboard.alert({
-                title: 'Auto-Organize',
-                message: 'The operation is going to take a little longer. The view will be updated on completion.'
-            });
-        }
-        else {
-
-            Dashboard.alert({
-                title: Globalize.translate('AutoOrganizeError'),
-                message: Globalize.translate('ErrorOrganizingFileWithErrorCode', e.headers.get('X-Application-Error-Code'))
-            });
-        }
-    }
-
     function getTabs() {
         return [
         {
@@ -317,7 +297,7 @@
 
             ApiClient.clearOrganizationLog().then(function () {
                 reloadItems(page);
-            }, onApiFailure);
+            }, Dashboard.processErrorResponse);
         });
 
     }).on('pageshow', '#libraryFileOrganizerLogPage', function () {

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizesmart.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizesmart.js
@@ -96,15 +96,6 @@
         $('.divMatchInfos', page).html(html);
     }
 
-    function onApiFailure(e) {
-
-        Dashboard.hideLoadingMsg();
-
-        Dashboard.alert({
-            message: Globalize.translate('DefaultErrorMessage')
-        });
-    }
-
     function getTabs() {
         return [
         {
@@ -142,7 +133,7 @@
 
                 reloadList(page);
 
-            }, onApiFailure);
+            }, Dashboard.processErrorResponse);
 
         });
 

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizetv.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/autoorganizetv.js
@@ -103,7 +103,7 @@
 
             tvOptions.CopyOriginalFile = $('#copyOrMoveFile', form).val();
 
-            ApiClient.updateNamedConfiguration('autoorganize', config).then(Dashboard.processServerConfigurationUpdateResult);
+            ApiClient.updateNamedConfiguration('autoorganize', config).then(Dashboard.processServerConfigurationUpdateResult, Dashboard.processErrorResponse);
         });
 
         return false;

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/dashboardhosting.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/dashboardhosting.js
@@ -16,7 +16,7 @@
             config.WanDdns = $('#txtDdns', form).val();
             config.CertificatePath = $('#txtCertificatePath', form).val();
 
-            ApiClient.updateServerConfiguration(config).then(Dashboard.processServerConfigurationUpdateResult);
+            ApiClient.updateServerConfiguration(config).then(Dashboard.processServerConfigurationUpdateResult, Dashboard.processErrorResponse);
         });
 
         // Disable default form submission

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/dlnaprofile.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/dlnaprofile.js
@@ -869,7 +869,7 @@
                 require(['toast'], function (toast) {
                     toast('Settings saved.');
                 });
-            });
+            }, Dashboard.processErrorResponse);
 
         } else {
 
@@ -882,7 +882,7 @@
 
                 Dashboard.navigate('dlnaprofiles.html');
 
-            });
+            }, Dashboard.processErrorResponse);
 
         }
 

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
@@ -455,6 +455,22 @@ var Dashboard = {
         });
     },
 
+    processErrorResponse: function (response) {
+
+        Dashboard.hideLoadingMsg();
+
+        var status = '' + response.status;
+
+        if (response.statusText) {
+            status = response.statusText;
+        }
+
+        Dashboard.alert({
+            title: status,
+            message: response.headers ? response.headers.get('X-Application-Error-Code') : null
+        });
+    },
+
     alert: function (options) {
 
         if (typeof options == "string") {


### PR DESCRIPTION
This commit adds a new dashboard method for generic handling of api errors.
It also changes local implementations to use the dashboard method.

This allows global control of error presentation (e.g. to switch to toast notifications if desired).