### PR TITLE
Collection meta-fetch fallback condition update

### DIFF
--- a/MediaBrowser.Providers/BoxSets/MovieDbBoxSetProvider.cs
+++ b/MediaBrowser.Providers/BoxSets/MovieDbBoxSetProvider.cs
@@ -190,7 +190,7 @@ namespace MediaBrowser.Providers.BoxSets
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (mainResult != null && string.IsNullOrEmpty(mainResult.overview))
+            if (mainResult != null && string.IsNullOrEmpty(mainResult.name))
             {
                 if (!string.IsNullOrEmpty(language) && !string.Equals(language, "en", StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
With this change I propose that english metadata from collection (fallback situation) occurs when a collection **NAME **is missing, instead of **OVERVIEW **(description).

This means a translated collection that has the vital information such as name will be sufficient to be used... not forcing Emby to download english data (with the non-translated title and overview) just because the translated version has an empty overview.

I took a while to understand why some of my collections weren't downloading their translated versions from provider. I traced the problem to this... the ones who had overview were pulled in, the ones who hadn't Emby used the fallback (easily seen in the logs).