### PR TITLE
Don't ignore accents in searchs

### DIFF
--- a/MediaBrowser.Server.Implementations/Library/SearchEngine.cs
+++ b/MediaBrowser.Server.Implementations/Library/SearchEngine.cs
@@ -86,13 +86,12 @@ namespace MediaBrowser.Server.Implementations.Library
         private Task<IEnumerable<SearchHintInfo>> GetSearchHints(SearchQuery query, User user)
         {
             var searchTerm = query.SearchTerm;
+            searchTerm = searchTerm.Trim();
 
             if (string.IsNullOrWhiteSpace(searchTerm))
             {
                 throw new ArgumentNullException("searchTerm");
             }
-
-            searchTerm = searchTerm.Trim().RemoveDiacritics();
 
             var terms = GetWords(searchTerm);
 
@@ -211,8 +210,6 @@ namespace MediaBrowser.Server.Implementations.Library
             {
                 throw new ArgumentNullException("input");
             }
-
-            input = input.RemoveDiacritics();
 
             if (string.Equals(input, searchInput, StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
**CHANGE 1:**
In 09/Jan/2015 the search code was changed (https://github.com/MediaBrowser/Emby/commit/2e9645c1e06428bf3223b015b0eac90afecef84f) so that accented chars get explicitly "unnacented" using .RemoveDiacritics()  function before submitted to search.

What I propose here is to stop doing this, because foreign users that try to search things that have accents can't do those searches at all:
- Ex: if a movie has "POLÍCIA" in it (police in portuguese), it can't be found writing POLI nor POLÍ in search field.

If there's ANY reason to removediacritics here... please let's discuss this.
If not... please accept this pull request.

ps: I tought about putting some commentaries like " // don't ever removediacritics here, it's bad for foreign users trying to do searches"  near the start of the function. Good or bad idea?

**CHANGE 2:**
I suggested bringing the Trim before the "isnullorwhitespace" check. Because if "spaces" are being typed without real chars, the expection will the thrown in that case.

Thanks