### PR TITLE
Small setPageTitle code optimizations

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/librarymenu.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/librarymenu.js
@@ -435,14 +435,8 @@
             if (selected) {
                 link.classList.add('selectedSidebarLink');
 
-                var title = '';
-
-                var secondaryTitle = (link.innerText || link.textContent).trim();
-                title += secondaryTitle;
-
-                var documentTitle = secondaryTitle;
-
-                Dashboard.setPageTitle(title, documentTitle);
+                var title = (link.innerText || link.textContent).trim();
+                Dashboard.setPageTitle(title);
 
             } else {
                 link.classList.remove('selectedSidebarLink');

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/site.js
@@ -1091,14 +1091,10 @@ var Dashboard = {
         });
     },
 
-    setPageTitle: function (title, documentTitle) {
+    setPageTitle: function (title) {
 
         LibraryMenu.setTitle(title || 'Emby');
-
-        documentTitle = documentTitle || title;
-        if (documentTitle) {
-            document.title = documentTitle;
-        }
+        document.title = (title || 'Emby');
     },
 
     getDisplayTime: function (ticks) {


### PR DESCRIPTION
With this pull request I propose the simplification of two files that are used to set "Title" in WebDashboard.

Original codes expected a situation where a secondary title could be used as fallback if the main title variable was empty. But one of those files ended putting both variables as same, which is illogical.

With this pull, I expected to optimize (very minimal, of course) the resources usage and make a cleaner code.