### PR TITLE
OmdbProvider: Drop IHasShortOverview stuff and other improvements

### DIFF
--- a/MediaBrowser.Api/ItemUpdateService.cs
+++ b/MediaBrowser.Api/ItemUpdateService.cs
@@ -292,12 +292,6 @@ namespace MediaBrowser.Api
                 hasTaglines.Taglines = request.Taglines;
             }
 
-            var hasShortOverview = item as IHasShortOverview;
-            if (hasShortOverview != null)
-            {
-                hasShortOverview.ShortOverview = request.ShortOverview;
-            }
-
             var hasKeywords = item as IHasKeywords;
             if (hasKeywords != null)
             {

--- a/MediaBrowser.Api/Reports/Activities/ReportActivitiesBuilder.cs
+++ b/MediaBrowser.Api/Reports/Activities/ReportActivitiesBuilder.cs
@@ -97,7 +97,7 @@ namespace MediaBrowser.Api.Reports
                         HeaderMetadata.Type,
                         HeaderMetadata.Severity,
 						HeaderMetadata.Name,
-                        HeaderMetadata.ShortOverview,
+                        //HeaderMetadata.ShortOverview,
 						HeaderMetadata.Overview,
                         //HeaderMetadata.UserId
                         //HeaderMetadata.Item,
@@ -135,11 +135,11 @@ namespace MediaBrowser.Api.Reports
                     option.Header.CanGroup = false;
                     break;
 
-                case HeaderMetadata.ShortOverview:
-                    option.Column = (i, r) => i.ShortOverview;
-                    option.Header.SortField = "";
-                    option.Header.CanGroup = false;
-                    break;
+                //case HeaderMetadata.ShortOverview:
+                //    option.Column = (i, r) => i.ShortOverview;
+                //    option.Header.SortField = "";
+                //    option.Header.CanGroup = false;
+                //    break;
 
                 case HeaderMetadata.Type:
                     option.Column = (i, r) => i.Type;

--- a/MediaBrowser.Api/Reports/Common/HeaderMetadata.cs
+++ b/MediaBrowser.Api/Reports/Common/HeaderMetadata.cs
@@ -56,7 +56,6 @@ namespace MediaBrowser.Api.Reports
 
         //Activity logs
         Overview,
-        ShortOverview,
         Type,
         Date,
         UserPrimaryImage,

--- a/MediaBrowser.Controller/Entities/Video.cs
+++ b/MediaBrowser.Controller/Entities/Video.cs
@@ -24,7 +24,6 @@ namespace MediaBrowser.Controller.Entities
         IHasTags,
         ISupportsPlaceHolders,
         IHasMediaSources,
-        IHasShortOverview,
         IThemeMedia,
         IArchivable
     {
@@ -62,7 +61,6 @@ namespace MediaBrowser.Controller.Entities
         public long? Size { get; set; }
         public string Container { get; set; }
         public int? TotalBitrate { get; set; }
-        public string ShortOverview { get; set; }
         public ExtraType? ExtraType { get; set; }
 
         /// <summary>

--- a/MediaBrowser.Controller/Providers/BaseItemXmlParser.cs
+++ b/MediaBrowser.Controller/Providers/BaseItemXmlParser.cs
@@ -266,23 +266,6 @@ namespace MediaBrowser.Controller.Providers
                         break;
                     }
 
-                case "ShortOverview":
-                    {
-                        var val = reader.ReadElementContentAsString();
-
-                        if (!string.IsNullOrWhiteSpace(val))
-                        {
-                            var hasShortOverview = item as IHasShortOverview;
-
-                            if (hasShortOverview != null)
-                            {
-                                hasShortOverview.ShortOverview = val;
-                            }
-                        }
-
-                        break;
-                    }
-
                 case "CriticRatingSummary":
                     {
                         var val = reader.ReadElementContentAsString();

--- a/MediaBrowser.Dlna/Didl/DidlBuilder.cs
+++ b/MediaBrowser.Dlna/Didl/DidlBuilder.cs
@@ -583,12 +583,6 @@ namespace MediaBrowser.Dlna.Didl
             {
                 var desc = item.Overview;
 
-                var hasShortOverview = item as IHasShortOverview;
-                if (hasShortOverview != null && !string.IsNullOrEmpty(hasShortOverview.ShortOverview))
-                {
-                    desc = hasShortOverview.ShortOverview;
-                }
-
                 if (!string.IsNullOrWhiteSpace(desc))
                 {
                     AddValue(element, "dc", "description", desc, NS_DC);

--- a/MediaBrowser.LocalMetadata/Savers/XmlSaverHelpers.cs
+++ b/MediaBrowser.LocalMetadata/Savers/XmlSaverHelpers.cs
@@ -79,6 +79,8 @@ namespace MediaBrowser.LocalMetadata.Savers
                     "MusicbrainzId",
 
                     "Overview",
+
+                    // Deprecated. No longer saving in this field.
                     "ShortOverview",
                     "Persons",
                     "PlotKeywords",
@@ -286,15 +288,6 @@ namespace MediaBrowser.LocalMetadata.Savers
                 }
             }
             
-            var hasShortOverview = item as IHasShortOverview;
-            if (hasShortOverview != null)
-            {
-                if (!string.IsNullOrEmpty(hasShortOverview.ShortOverview))
-                {
-                    builder.Append("<ShortOverview><![CDATA[" + hasShortOverview.ShortOverview + "]]></ShortOverview>");
-                }
-            }
-
             if (!string.IsNullOrEmpty(item.CustomRating))
             {
                 builder.Append("<CustomRating>" + SecurityElement.Escape(item.CustomRating) + "</CustomRating>");

--- a/MediaBrowser.Model/Querying/ItemFields.cs
+++ b/MediaBrowser.Model/Querying/ItemFields.cs
@@ -183,11 +183,6 @@
         Settings,
 
         /// <summary>
-        /// The short overview
-        /// </summary>
-        ShortOverview,
-
-        /// <summary>
         /// The screenshot image tags
         /// </summary>
         ScreenshotImageTags,

--- a/MediaBrowser.Providers/Manager/ProviderUtils.cs
+++ b/MediaBrowser.Providers/Manager/ProviderUtils.cs
@@ -214,7 +214,6 @@ namespace MediaBrowser.Providers.Manager
             MergeAwards(source, target, lockedFields, replaceData);
             MergeTaglines(source, target, lockedFields, replaceData);
             MergeTrailers(source, target, lockedFields, replaceData);
-            MergeShortOverview(source, target, lockedFields, replaceData);
 
             if (mergeMetadataSettings)
             {
@@ -245,20 +244,6 @@ namespace MediaBrowser.Providers.Manager
             if (sourceHasDisplayOrder != null && targetHasDisplayOrder != null)
             {
                 targetHasDisplayOrder.DisplayOrder = sourceHasDisplayOrder.DisplayOrder;
-            }
-        }
-
-        private static void MergeShortOverview(BaseItem source, BaseItem target, List<MetadataFields> lockedFields, bool replaceData)
-        {
-            var sourceHasShortOverview = source as IHasShortOverview;
-            var targetHasShortOverview = target as IHasShortOverview;
-
-            if (sourceHasShortOverview != null && targetHasShortOverview != null)
-            {
-                if (replaceData || string.IsNullOrEmpty(targetHasShortOverview.ShortOverview))
-                {
-                    targetHasShortOverview.ShortOverview = sourceHasShortOverview.ShortOverview;
-                }
             }
         }
 

--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -465,11 +465,6 @@ namespace MediaBrowser.Providers.MediaInfo
                     video.Overview = data.Overview;
                 }
             }
-
-            if (string.IsNullOrWhiteSpace(video.ShortOverview) || isFullRefresh)
-            {
-                video.ShortOverview = data.ShortOverview;
-            }
         }
 
         private async Task FetchPeople(Video video, Model.MediaInfo.MediaInfo data, MetadataRefreshOptions options)

--- a/MediaBrowser.Providers/Omdb/OmdbItemProvider.cs
+++ b/MediaBrowser.Providers/Omdb/OmdbItemProvider.cs
@@ -220,7 +220,7 @@ namespace MediaBrowser.Providers.Omdb
                 result.Item.SetProviderId(MetadataProviders.Imdb, imdbId);
                 result.HasMetadata = true;
 
-                await new OmdbProvider(_jsonSerializer, _httpClient).Fetch(result.Item, imdbId, info.MetadataLanguage, info.MetadataCountryCode, cancellationToken).ConfigureAwait(false);
+                await new OmdbProvider(_jsonSerializer, _httpClient).Fetch(result, imdbId, info.MetadataLanguage, info.MetadataCountryCode, cancellationToken).ConfigureAwait(false);
             }
 
             return result;
@@ -259,7 +259,7 @@ namespace MediaBrowser.Providers.Omdb
                 result.Item.SetProviderId(MetadataProviders.Imdb, imdbId);
                 result.HasMetadata = true;
 
-                await new OmdbProvider(_jsonSerializer, _httpClient).Fetch(result.Item, imdbId, info.MetadataLanguage, info.MetadataCountryCode, cancellationToken).ConfigureAwait(false);
+                await new OmdbProvider(_jsonSerializer, _httpClient).Fetch(result, imdbId, info.MetadataLanguage, info.MetadataCountryCode, cancellationToken).ConfigureAwait(false);
             }
 
             return result;

--- a/MediaBrowser.Providers/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Omdb/OmdbProvider.cs
@@ -124,16 +124,19 @@ namespace MediaBrowser.Providers.Omdb
 
                 if (!string.IsNullOrWhiteSpace(omdbItem.Actors))
                 {
-                    var actorList = omdbItem.Actors.Split(new []{',', ' '}, StringSplitOptions.RemoveEmptyEntries);
+                    var actorList = result.Actors.Split(',');
                     foreach (var actor in actorList)
                     {
-                        var person = new PersonInfo
+                        if (!string.IsNullOrWhiteSpace(actor))
                         {
-                            Name = actor,
-                            Type = PersonType.Actor
-                        };
+                            var person = new PersonInfo
+                            {
+                                Name = actor.Trim(),
+                                Type = PersonType.Actor
+                            };
 
-                        result.AddPerson(person);
+                            result.AddPerson(person);
+                        }
                     }
                 }
 

--- a/MediaBrowser.Providers/TV/Omdb/OmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/Omdb/OmdbEpisodeProvider.cs
@@ -38,7 +38,12 @@ namespace MediaBrowser.Providers.TV
         {
             var result = new MetadataResult<Episode>
             {
-                Item = new Episode()
+                Item = new Episode
+				{
+                    IndexNumber = info.IndexNumber,
+                    ParentIndexNumber = info.ParentIndexNumber,
+                    IndexNumberEnd = info.IndexNumberEnd
+				}
             };
 
             // Allowing this will dramatically increase scan times
@@ -58,7 +63,7 @@ namespace MediaBrowser.Providers.TV
                 result.Item.SetProviderId(MetadataProviders.Imdb, imdbId);
                 result.HasMetadata = true;
 
-                await new OmdbProvider(_jsonSerializer, _httpClient).Fetch(result.Item, imdbId, info.MetadataLanguage, info.MetadataCountryCode, cancellationToken).ConfigureAwait(false);
+                await new OmdbProvider(_jsonSerializer, _httpClient).Fetch(result, imdbId, info.MetadataLanguage, info.MetadataCountryCode, cancellationToken).ConfigureAwait(false);
             }
 
             return result;

--- a/MediaBrowser.Server.Implementations/Dto/DtoService.cs
+++ b/MediaBrowser.Server.Implementations/Dto/DtoService.cs
@@ -1125,15 +1125,6 @@ namespace MediaBrowser.Server.Implementations.Dto
                 dto.OriginalTitle = item.OriginalTitle;
             }
 
-            if (fields.Contains(ItemFields.ShortOverview))
-            {
-                var hasShortOverview = item as IHasShortOverview;
-                if (hasShortOverview != null)
-                {
-                    dto.ShortOverview = hasShortOverview.ShortOverview;
-                }
-            }
-
             // If there are no backdrops, indicate what parent has them in case the Ui wants to allow inheritance
             if (backdropLimit > 0 && dto.BackdropImageTags.Count == 0)
             {

--- a/MediaBrowser.WebDashboard/dashboard-ui/components/metadataeditor/metadataeditor.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/components/metadataeditor/metadataeditor.js
@@ -149,7 +149,6 @@
                 Metascore: $('#txtMetascore', form).val(),
                 AwardSummary: $('#txtAwardSummary', form).val(),
                 Overview: $('#txtOverview', form).val(),
-                ShortOverview: $('#txtShortOverview', form).val(),
                 Status: $('#selectStatus', form).val(),
                 AirDays: getSelectedAirDays(form),
                 AirTime: $('#txtAirTime', form).val(),
@@ -818,7 +817,6 @@
         $('#txtName', context).val(item.Name || "");
         $('#txtOriginalName', context).val(item.OriginalTitle || "");
         context.querySelector('#txtOverview').value = item.Overview || '';
-        $('#txtShortOverview', context).val(item.ShortOverview || "");
         $('#txtTagline', context).val((item.Taglines && item.Taglines.length ? item.Taglines[0] : ''));
         $('#txtSortName', context).val(item.ForcedSortName || "");
         $('#txtDisplayMediaType', context).val(item.DisplayMediaType || "");
@@ -1133,12 +1131,6 @@
                 $('#btnEditImages', context).hide();
             } else {
                 $('#btnEditImages', context).show();
-            }
-
-            if (item.MediaType == "Video" && item.Type != "Episode") {
-                $('#fldShortOverview', context).show();
-            } else {
-                $('#fldShortOverview', context).hide();
             }
 
             if (item.MediaType == "Video" && item.Type != "Episode") {

--- a/MediaBrowser.WebDashboard/dashboard-ui/components/metadataeditor/metadataeditor.template.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/components/metadataeditor/metadataeditor.template.html
@@ -85,9 +85,6 @@
                 <paper-textarea id="txtOverview"></paper-textarea>
                 <br />
             </div>
-            <div id="fldShortOverview" style="display: none;">
-                <paper-input id="txtShortOverview" type="text" label="${LabelShortOverview}"></paper-input>
-            </div>
             <div id="fldPremiereDate">
                 <paper-input id="txtPremiereDate" label="${LabelReleaseDate}" type="date"></paper-input>
             </div>

--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -361,22 +361,6 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                         break;
                     }
 
-                case "outline":
-                    {
-                        var val = reader.ReadElementContentAsString();
-
-                        if (!string.IsNullOrWhiteSpace(val))
-                        {
-                            var hasShortOverview = item as IHasShortOverview;
-
-                            if (hasShortOverview != null)
-                            {
-                                hasShortOverview.ShortOverview = val;
-                            }
-                        }
-                        break;
-                    }
-
                 case "biography":
                 case "plot":
                 case "review":

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -445,20 +445,6 @@ namespace MediaBrowser.XbmcMetadata.Savers
                 writer.WriteElementString("plot", overview);
             }
 
-            var hasShortOverview = item as IHasShortOverview;
-            if (hasShortOverview != null)
-            {
-                var outline = (hasShortOverview.ShortOverview ?? string.Empty)
-                    .StripHtml()
-                    .Replace("&quot;", "'");
-
-                writer.WriteElementString("outline", outline);
-            }
-            else
-            {
-                writer.WriteElementString("outline", overview);
-            }
-
             if (!string.IsNullOrWhiteSpace(item.CustomRating))
             {
                 writer.WriteElementString("customrating", item.CustomRating);


### PR DESCRIPTION
- Changed OmdbProvider to use full plot information
- All the "ShortOverview" stuff is no longer required and has been
removed
- Enhanced OmdbProvider to return actors, director and writer data
- Fixed bug in OmdbEpisodeProvider generating invalid SortName values
due to missing IndexNumber and ParentIndexNumber values