### PR TITLE
Improve result display for itemidentifier

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/components/itemidentifier/itemidentifier.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/components/itemidentifier/itemidentifier.js
@@ -150,6 +150,15 @@
         var html = '';
         var cssClass = "card";
 
+        var title = result.SearchProviderName || "";
+        title = title + "\n";
+
+        if (result.ProviderIds) {
+            for (var idItem in result.ProviderIds) {
+                title = title + "\n" + idItem + ": " + result.ProviderIds[idItem];
+            }
+        }
+
         if (currentItemType == "Episode") {
             cssClass += " backdropCard";
         }
@@ -160,7 +169,7 @@
             cssClass += " portraitCard";
         }
 
-        html += '<div class="' + cssClass + '">';
+        html += '<div class="' + cssClass + '" title="' + title + '">';
         html += '<div class="cardBox">';
         html += '<div class="cardScalable">';
         html += '<div class="cardPadder"></div>';
@@ -179,7 +188,7 @@
         html += '</div>';
 
         html += '<div class="cardFooter outerCardFooter">';
-        html += '<div class="cardText cardTextCentered">' + result.Name + '</div>';
+        html += '<div class="cardText2Lines cardTextCentered">' + result.Name + '</div>';
 
         html += '<div class="cardText cardTextCentered">';
         html += result.ProductionYear || '&nbsp;';

--- a/MediaBrowser.WebDashboard/dashboard-ui/css/card.css
+++ b/MediaBrowser.WebDashboard/dashboard-ui/css/card.css
@@ -219,6 +219,17 @@ iron-list .card {
     line-height: 1.4;
 }
 
+.cardText2Lines {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    text-wrap:normal;
+    white-space:normal;
+    padding: 5px 5px 2px;
+    font-weight: 400;
+    line-height: 1.4em;
+    height: 2.8em;
+}
+
 .cardButtonContainer {
     text-align: right;
     float: right;


### PR DESCRIPTION
In many cases the titles were displayed truncated (with ellipsis) and it was impossible to decide if an item is the desired one.

This commit changes the card title to wrap over 2 lines.

I also added a tooltip to the search results indicating from which provider a result item came from and which provider ids it has reported
