### PR TITLE
Constrain movie suggestiions to current library

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/moviesrecommended.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/moviesrecommended.js
@@ -211,6 +211,7 @@
 
         var url = ApiClient.getUrl("Movies/Recommendations", {
 
+            ParentId: parentId,
             userId: userId,
             categoryLimit: 6,
             ItemLimit: screenWidth >= 1920 ? 8 : (screenWidth >= 1600 ? 7 : (screenWidth >= 1200 ? 6 : 5)),


### PR DESCRIPTION
Just like "Resume" and "Latest Movies", the suggestions should be
restricted to the current library as well.

(appears like it was intended anyway but probably forgotten?)