### PR TITLE
Fix Country Metadata country code returning

### DIFF
--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1246,7 +1246,7 @@ namespace MediaBrowser.Controller.Entities
                 lang = ConfigurationManager.Configuration.PreferredMetadataLanguage;
             }
 
-            return lang;
+            return lang.Split('-')[0].ToLower();
         }
 
         /// <summary>


### PR DESCRIPTION
After the recent changes where Country-Region (Ex: pt-BR) were finally considered when fetching metadata from providers (instead of only pt), download of metadata got fixed... but image download has been broken, just figured it today, when I noticed that images of "pt" country aren't being downloaded with priority as usual from providers.

What happens today is: our image providers don't support full country-Region format (Ex: pt-BR), which only leaves country code (Ex: pt) to be used as parameter.

This change proposes that, if LANG has 2 parts, only the first part gets returned so images can be again priorized correctly for those kind of countries.

In some exception cases, actually an image from other region may be downloaded (Ex: pt-PT, in my case), but that's a little better than ALWAYS getting wrong ("en", a generic fallback), because I can adjust those exceptions manually when needed

Please consider.

ps: I hope my change actually gets the fix done. If not, devs please let's fix this