### PR TITLE
Remote Trailers support at episode Level

### DIFF
--- a/MediaBrowser.Controller/Entities/TV/Episode.cs
+++ b/MediaBrowser.Controller/Entities/TV/Episode.cs
@@ -11,13 +11,25 @@ namespace MediaBrowser.Controller.Entities.TV
     /// <summary>
     /// Class Episode
     /// </summary>
-    public class Episode : Video, IHasLookupInfo<EpisodeInfo>, IHasSeries
+    public class Episode : Video, IHasTrailers, IHasLookupInfo<EpisodeInfo>, IHasSeries
     {
-        /// <summary>
-        /// Gets the season in which it aired.
-        /// </summary>
-        /// <value>The aired season.</value>
-        public int? AirsBeforeSeasonNumber { get; set; }
+
+        public Episode()
+        {
+            RemoteTrailers = new List<MediaUrl>();
+            LocalTrailerIds = new List<Guid>();
+            RemoteTrailerIds = new List<Guid>();
+        }
+
+        public List<Guid> LocalTrailerIds { get; set; }
+        public List<Guid> RemoteTrailerIds { get; set; }
+        public List<MediaUrl> RemoteTrailers { get; set; }
+
+    /// <summary>
+    /// Gets the season in which it aired.
+    /// </summary>
+    /// <value>The aired season.</value>
+    public int? AirsBeforeSeasonNumber { get; set; }
         public int? AirsAfterSeasonNumber { get; set; }
         public int? AirsBeforeEpisodeNumber { get; set; }
 


### PR DESCRIPTION
Minimal changes to support linking remote trailers [eg. YouTube] to episodes, to support manual editing or future meta providers [eg. tvmaze one the api includes this info]