### PR TITLE
TheMovieDB image fetching for now only supports 2-digit lang code (ISO-639-1)

### DIFF
--- a/MediaBrowser.Providers/BoxSets/MovieDbBoxSetImageProvider.cs
+++ b/MediaBrowser.Providers/BoxSets/MovieDbBoxSetImageProvider.cs
@@ -53,7 +53,7 @@ namespace MediaBrowser.Providers.BoxSets
 
             if (!string.IsNullOrEmpty(tmdbId))
             {
-                var language = item.GetPreferredMetadataLanguage();
+                var language = item.GetPreferredMetadataLanguage().Split('-')[0].ToLower();
 
                 var mainResult = await MovieDbBoxSetProvider.Current.GetMovieDbResult(tmdbId, null, cancellationToken).ConfigureAwait(false);
 

--- a/MediaBrowser.Providers/Movies/MovieDbImageProvider.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbImageProvider.cs
@@ -107,7 +107,7 @@ namespace MediaBrowser.Providers.Movies
                 }));
             }
 
-            var language = item.GetPreferredMetadataLanguage();
+            var language = item.GetPreferredMetadataLanguage().Split('-')[0].ToLower();
 
             var isLanguageEn = string.Equals(language, "en", StringComparison.OrdinalIgnoreCase);
 

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbEpisodeImageProvider.cs
@@ -76,7 +76,7 @@ namespace MediaBrowser.Providers.TV
                 RatingType = RatingType.Score
             }));
 
-            var language = item.GetPreferredMetadataLanguage();
+            var language = item.GetPreferredMetadataLanguage().Split('-')[0].ToLower();
 
             var isLanguageEn = string.Equals(language, "en", StringComparison.OrdinalIgnoreCase);
 

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeriesImageProvider.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeriesImageProvider.cs
@@ -91,7 +91,7 @@ namespace MediaBrowser.Providers.TV
                 RatingType = RatingType.Score
             }));
 
-            var language = item.GetPreferredMetadataLanguage();
+            var language = item.GetPreferredMetadataLanguage().Split('-')[0].ToLower();
 
             var isLanguageEn = string.Equals(language, "en", StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
So far, TheMovieDB only supports 2-digit language code for image fetching, as all images are tagged that way.

So this change allows users to fetch images with better chance of getting his language's, instead of falling back to English every time, trying to fetch the exact country-Region format.

As stated in https://www.themoviedb.org/talk/574dc1c592514112080000a1 , the devs of TheMovieDB believe that eventually they'll have to implement the country-Region options.