### PR TITLE
Adjust preferred language for image searches in TMDB

### DIFF
--- a/MediaBrowser.Providers/BoxSets/MovieDbBoxSetImageProvider.cs
+++ b/MediaBrowser.Providers/BoxSets/MovieDbBoxSetImageProvider.cs
@@ -53,7 +53,7 @@ namespace MediaBrowser.Providers.BoxSets
 
             if (!string.IsNullOrEmpty(tmdbId))
             {
-                var language = item.GetPreferredMetadataLanguage();
+                var language = item.GetPreferredMetadataLanguage().Split('-')[0].ToLower();
 
                 var mainResult = await MovieDbBoxSetProvider.Current.GetMovieDbResult(tmdbId, null, cancellationToken).ConfigureAwait(false);
 

--- a/MediaBrowser.Providers/Movies/MovieDbImageProvider.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbImageProvider.cs
@@ -107,7 +107,7 @@ namespace MediaBrowser.Providers.Movies
                 }));
             }
 
-            var language = item.GetPreferredMetadataLanguage();
+            var language = item.GetPreferredMetadataLanguage().Split('-')[0].ToLower();
 
             var isLanguageEn = string.Equals(language, "en", StringComparison.OrdinalIgnoreCase);
 

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbEpisodeImageProvider.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbEpisodeImageProvider.cs
@@ -76,7 +76,7 @@ namespace MediaBrowser.Providers.TV
                 RatingType = RatingType.Score
             }));
 
-            var language = item.GetPreferredMetadataLanguage();
+            var language = item.GetPreferredMetadataLanguage().Split('-')[0].ToLower();
 
             var isLanguageEn = string.Equals(language, "en", StringComparison.OrdinalIgnoreCase);
 

--- a/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeriesImageProvider.cs
+++ b/MediaBrowser.Providers/TV/TheMovieDb/MovieDbSeriesImageProvider.cs
@@ -91,7 +91,7 @@ namespace MediaBrowser.Providers.TV
                 RatingType = RatingType.Score
             }));
 
-            var language = item.GetPreferredMetadataLanguage();
+            var language = item.GetPreferredMetadataLanguage().Split('-')[0].ToLower();
 
             var isLanguageEn = string.Equals(language, "en", StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
TMDB images are unfortunately tagged with 2-digit (ISO-639-1) languages, instead of full Lang-Country format (Ex: pt-BR, en-GB...)

This way... when requests where made with full format, instead of getting correct or language-related results using preferred metadata language, it is falling back to english (en), as TMDB doesn't recognize (until now) Lang-Country full format.

Topic https://www.themoviedb.org/talk/574dc1c592514112080000a1?page=1 in TMDB forum refers to the case.
Devs states that eventually the full format will be supported... we just don't know when. Until then, let's use this method as alternative.

**PS: proposing merge to master because DEV and BETA weren't mergeable.**