### PR TITLE
OmdbProvider: Fix for empty json fields

### DIFF
--- a/MediaBrowser.Providers/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Omdb/OmdbProvider.cs
@@ -56,7 +56,7 @@ namespace MediaBrowser.Providers.Omdb
                     resultString = reader.ReadToEnd();
                 }
 
-                resultString = resultString.Replace("\"N/A\"", string.Empty);
+                resultString = resultString.Replace("\"N/A\"", "\"\"");
 
                 var result = _jsonSerializer.DeserializeFromString<RootObject>(resultString);
 


### PR DESCRIPTION
Avoid malformed json because some day jsonserializer may change its behaviour or be replaced by something less tolerant...