### PR TITLE
Channelinterface enhancements

### DIFF
--- a/MediaBrowser.Controller/Channels/ChannelItemInfo.cs
+++ b/MediaBrowser.Controller/Channels/ChannelItemInfo.cs
@@ -53,6 +53,8 @@ namespace MediaBrowser.Controller.Channels
 
         public bool IsInfiniteStream { get; set; }
 
+        public string HomePageUrl { get; set; }
+
         public ChannelItemInfo()
         {
             MediaSources = new List<ChannelMediaInfo>();

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1517,10 +1517,10 @@ namespace MediaBrowser.Controller.Entities
 
         public virtual string GetClientTypeName()
         {
-            if (IsFolder && SourceType == SourceType.Channel && !(this is Channel))
-            {
-                return "ChannelFolderItem";
-            }
+            ////if (IsFolder && SourceType == SourceType.Channel && !(this is Channel))
+            ////{
+            ////    return "ChannelFolderItem";
+            ////}
 
             return GetType().Name;
         }

--- a/MediaBrowser.Model/Channels/ChannelMediaContentType.cs
+++ b/MediaBrowser.Model/Channels/ChannelMediaContentType.cs
@@ -18,6 +18,8 @@
 
         TvExtra = 7,
 
-        GameExtra = 8
+        GameExtra = 8,
+
+        Person = 9
     }
 }

--- a/MediaBrowser.Model/Channels/ChannelMediaType.cs
+++ b/MediaBrowser.Model/Channels/ChannelMediaType.cs
@@ -6,6 +6,8 @@
 
         Video = 1,
 
-        Photo = 2
+        Photo = 2,
+
+        Person = 3
     }
 }

--- a/MediaBrowser.Server.Implementations/Channels/ChannelManager.cs
+++ b/MediaBrowser.Server.Implementations/Channels/ChannelManager.cs
@@ -133,7 +133,7 @@ namespace MediaBrowser.Server.Implementations.Channels
             if (query.IsFavorite.HasValue)
             {
                 var val = query.IsFavorite.Value;
-                channels = channels.Where(i => _userDataManager.GetUserData(user,  i).IsFavorite == val)
+                channels = channels.Where(i => _userDataManager.GetUserData(user, i).IsFavorite == val)
                     .ToList();
             }
 
@@ -1280,6 +1280,10 @@ namespace MediaBrowser.Server.Implementations.Channels
                 {
                     item = GetItemById<Movie>(info.Id, channelProvider.Name, channelProvider.DataVersion, out isNew);
                 }
+                else if (info.ContentType == ChannelMediaContentType.Person)
+                {
+                    item = GetItemById<Person>(info.Id, channelProvider.Name, channelProvider.DataVersion, out isNew);
+                }
                 else if (info.ContentType == ChannelMediaContentType.Trailer || info.ExtraType == ExtraType.Trailer)
                 {
                     item = GetItemById<Trailer>(info.Id, channelProvider.Name, channelProvider.DataVersion, out isNew);
@@ -1341,6 +1345,11 @@ namespace MediaBrowser.Server.Implementations.Channels
 
                 var mediaSource = info.MediaSources.FirstOrDefault();
                 item.Path = mediaSource == null ? null : mediaSource.Path;
+
+                if (info.People != null)
+                {
+                    channelAudioItem.Artists = info.People.Select(e => e.Name).ToList();
+                }
             }
 
             var channelVideoItem = item as Video;

--- a/MediaBrowser.Server.Implementations/Channels/ChannelManager.cs
+++ b/MediaBrowser.Server.Implementations/Channels/ChannelManager.cs
@@ -1172,8 +1172,8 @@ namespace MediaBrowser.Server.Implementations.Channels
         {
             items = ApplyFilters(items, query.Filters, user);
 
-            var sortBy = query.SortBy.Length == 0 ? new[] { ItemSortBy.SortName } : query.SortBy;
-            items = _libraryManager.Sort(items, user, sortBy, query.SortOrder ?? SortOrder.Ascending);
+            //var sortBy = query.SortBy.Length == 0 ? new[] { ItemSortBy.SortName } : query.SortBy;
+            items = _libraryManager.Sort(items, user, query.SortBy, query.SortOrder ?? SortOrder.Ascending);
 
             var all = items.ToList();
             var totalCount = totalCountFromProvider ?? all.Count;
@@ -1270,6 +1270,14 @@ namespace MediaBrowser.Server.Implementations.Channels
                     item = GetItemById<Audio>(info.Id, channelProvider.Name, channelProvider.DataVersion, out isNew);
                 }
             }
+            else if (info.MediaType == ChannelMediaType.Photo)
+            {
+                item = GetItemById<Photo>(info.Id, channelProvider.Name, channelProvider.DataVersion, out isNew);
+            }
+            else if (info.MediaType == ChannelMediaType.Person && info.ContentType == ChannelMediaContentType.Person)
+            {
+                    item = GetItemById<Person>(info.Id, channelProvider.Name, channelProvider.DataVersion, out isNew);
+            }
             else
             {
                 if (info.ContentType == ChannelMediaContentType.Episode)
@@ -1311,6 +1319,7 @@ namespace MediaBrowser.Server.Implementations.Channels
                 item.OfficialRating = info.OfficialRating;
                 item.DateCreated = info.DateCreated ?? DateTime.UtcNow;
                 item.Tags = info.Tags;
+                item.HomePageUrl = info.HomePageUrl;
             }
 
             var trailer = item as Trailer;
@@ -1336,6 +1345,17 @@ namespace MediaBrowser.Server.Implementations.Channels
                 forceUpdate = true;
             }
             item.ExternalId = info.Id;
+
+            var channelMusicAlbum = item as MusicAlbum;
+            if (channelMusicAlbum != null)
+            {
+                if (info.People != null)
+                {
+                    channelMusicAlbum.AlbumArtists = info.People.Select(e => e.Name).ToList();
+                    channelMusicAlbum.Artists = info.People.Select(e => e.Name).ToList();
+                    forceUpdate = true;
+                }
+            }
 
             var channelAudioItem = item as Audio;
             if (channelAudioItem != null)

--- a/MediaBrowser.WebDashboard/dashboard-ui/css/librarybrowser.css
+++ b/MediaBrowser.WebDashboard/dashboard-ui/css/librarybrowser.css
@@ -210,6 +210,10 @@
     font-weight: normal !important;
 }
 
+.itemOverview {
+    white-space: pre-wrap;
+}
+
 a.itemTag:hover {
     background-color: #2489ce;
 }

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/librarybrowser.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/librarybrowser.js
@@ -1104,6 +1104,9 @@
                 if (item.Type == "Channel") {
                     return "channelitems.html?id=" + id;
                 }
+                if (item.Type == "MusicAlbum") {
+                    return "itemdetails.html?id=" + id;
+                }
                 if ((item.IsFolder && item.SourceType == 'Channel') || item.Type == 'ChannelFolderItem') {
                     return "channelitems.html?id=" + item.ChannelId + '&folderId=' + item.Id;
                 }
@@ -1112,9 +1115,6 @@
                 }
 
                 if (item.Type == "BoxSet") {
-                    return "itemdetails.html?id=" + id;
-                }
-                if (item.Type == "MusicAlbum") {
                     return "itemdetails.html?id=" + id;
                 }
                 if (item.Type == "GameSystem") {


### PR DESCRIPTION
- Added ChannelMediaContentType.Person
- remove override for GetClientTypeName (either globally but at least for MusicAlbum!)
- Fix rendering of MusicAlbums from channels as albums
- css: .itemOverview - preserve line breaks from source string
- If the channel plugin clears all sort fields: Don't fallback to name
  sorting (clearing sort fields means that the plugin doesn't want any
  sorting)
- Added appropriate handlng for photo items
- Added handling for (the new) person items
- Improved handling of MusicAlbum items (setting artists from people
  items)
- Added HomePageUrl field to ChannelItemInfo
