### PR TITLE
Disable FIPS Validation Check in App.config

### DIFF
--- a/MediaBrowser.ServerApplication/App.config
+++ b/MediaBrowser.ServerApplication/App.config
@@ -52,6 +52,7 @@
         <bindingRedirect oldVersion="0.0.0.0-2.3.6.0" newVersion="2.3.6.0"/>
       </dependentAssembly>
     </assemblyBinding>
+    <enforceFIPSPolicy enabled="false"/>
   </runtime>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">


### PR DESCRIPTION
Disables the FIPS Validation Check to allow the MediaBrowser Server Application to run on a Trusted Platform enabled computer running Windows 10. Important information regarding the addition can be found on MSDN: https://msdn.microsoft.com/en-us/library/hh202806(v=vs.110).aspx

While in our discussions with Microsoft Government and Enterprise Support it has been indicated that it's best practice to move to a FIPS validated encryption method (please see MSDN: https://msdn.microsoft.com/en-us/library/0ss79b2x(v=vs.110).aspx to determine an appropriate algorithm), this patch will at minimum allow the application to run by specifying whether to enforce a computer configuration requirement that cryptographic algorithms must comply with the Federal Information Processing Standards or "FIPS."

Please see http://emby.media/community/index.php?/topic/35875-fips-validated-cryptography-fix/ for discussion on the proposed fix.