### PR TITLE
Fix incorrect library title being set on back/forward browser navigation

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/channelitems.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/channelitems.html
@@ -1,4 +1,4 @@
-﻿<div id="channelItemsPage" data-role="page" class="page libraryPage channelsPage noSecondaryNavPage" data-contextname="${HeaderChannels}" data-require="scripts/channelitems" data-backbutton="true" data-menubutton="false">
+﻿<div id="channelItemsPage" data-role="page" class="page libraryPage channelsPage noSecondaryNavPage" data-require="scripts/channelitems" data-backbutton="true" data-menubutton="false">
 
     <div data-role="content">
         <div class="viewSettings">


### PR DESCRIPTION
This commit removes the data-contextname attribute which was leading to incorrect view titles being set.
The (correct) title is always set from script anyway...