### PR TITLE
Preserve line breaks in item overview

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/css/librarybrowser.css
+++ b/MediaBrowser.WebDashboard/dashboard-ui/css/librarybrowser.css
@@ -210,6 +210,10 @@
     font-weight: normal !important;
 }
 
+.itemOverview {
+    white-space: pre-wrap;
+}
+
 a.itemTag:hover {
     background-color: #2489ce;
 }


### PR DESCRIPTION
This would be one way to preserve line breaks in overview descriptions.

Another method would be to insert BR tags during acquisition of the description data...