### PR TITLE
Channel item sort must not default to name sorting when all sort fields are cleared

### DIFF
--- a/MediaBrowser.Server.Implementations/Channels/ChannelManager.cs
+++ b/MediaBrowser.Server.Implementations/Channels/ChannelManager.cs
@@ -1172,8 +1172,7 @@ namespace MediaBrowser.Server.Implementations.Channels
         {
             items = ApplyFilters(items, query.Filters, user);
 
-            var sortBy = query.SortBy.Length == 0 ? new[] { ItemSortBy.SortName } : query.SortBy;
-            items = _libraryManager.Sort(items, user, sortBy, query.SortOrder ?? SortOrder.Ascending);
+            items = _libraryManager.Sort(items, user, query.SortBy, query.SortOrder ?? SortOrder.Ascending);
 
             var all = items.ToList();
             var totalCount = totalCountFromProvider ?? all.Count;


### PR DESCRIPTION
A channel plugin must be able to present items in just the order in which it provides items to the host.

This is the "Default" sort order option. In this case, Emby must not perform sorting by "Name".

Sorting by "Name" is a different option. A user can set this or the channel can set this. But if the "Default" option is selected, items must not be sorted by "SortName"
