### PR TITLE
Changed to a valid preset for h264_nvenc

### DIFF
--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -341,7 +341,7 @@ namespace MediaBrowser.Api.Playback
             // h264 (h264_nvenc)
             else if (string.Equals(videoCodec, "h264_nvenc", StringComparison.OrdinalIgnoreCase))
             {
-                param = "-preset high-performance";
+                param = "-preset default";
             }
 
             // webm


### PR DESCRIPTION
When using h264_nvenc, the preset is set to "high-performance" which isn't a valid preset according to the nvenc encoder. For now it's set to default to get a working version.