### PR TITLE
Fix: Incorrect use of DateTime.ToUniversalTime() results in incorrect dates returned by metadata providers

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderUtils.cs
+++ b/MediaBrowser.Providers/Manager/ProviderUtils.cs
@@ -236,6 +236,39 @@ namespace MediaBrowser.Providers.Manager
             }
         }
 
+        public static TimeZoneInfo GetUsEasternTimeZoneInfo()
+        {
+            TimeZoneInfo easternZone = null;
+
+            try
+            {
+                // Windows
+                easternZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            }
+            catch (TimeZoneNotFoundException)
+            {
+            }
+
+            if (easternZone == null)
+            {
+                try
+                {
+                    // Mono/Linux
+                    easternZone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+                }
+                catch (TimeZoneNotFoundException)
+                {
+                }
+            }
+
+            if (easternZone == null)
+            {
+                easternZone = TimeZoneInfo.CreateCustomTimeZone("Custom_EST", TimeSpan.FromHours(-5), "Custom_EST", "Custom_EST");
+            }
+
+            return easternZone;
+        }
+
         private static void MergeShortOverview(BaseItem source, BaseItem target, List<MetadataFields> lockedFields, bool replaceData)
         {
             var sourceHasShortOverview = source as IHasShortOverview;

--- a/MediaBrowser.Providers/Movies/GenericMovieDbInfo.cs
+++ b/MediaBrowser.Providers/Movies/GenericMovieDbInfo.cs
@@ -14,6 +14,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using CommonIO;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.Movies
 {
@@ -223,7 +224,7 @@ namespace MediaBrowser.Providers.Movies
                 // These dates are always in this exact format
                 if (DateTime.TryParse(movieData.release_date, _usCulture, DateTimeStyles.None, out r))
                 {
-                    movie.PremiereDate = r.ToUniversalTime();
+                    movie.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(r, ProviderUtils.GetUsEasternTimeZoneInfo());
                     movie.ProductionYear = movie.PremiereDate.Value.Year;
                 }
             }

--- a/MediaBrowser.Providers/Movies/MovieDbProvider.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbProvider.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using CommonIO;
 using MediaBrowser.Common;
 using MediaBrowser.Model.Net;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.Movies
 {
@@ -94,7 +95,7 @@ namespace MediaBrowser.Providers.Movies
                     // These dates are always in this exact format
                     if (DateTime.TryParse(obj.release_date, _usCulture, DateTimeStyles.None, out r))
                     {
-                        remoteResult.PremiereDate = r.ToUniversalTime();
+                        remoteResult.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(r, ProviderUtils.GetUsEasternTimeZoneInfo());
                         remoteResult.ProductionYear = remoteResult.PremiereDate.Value.Year;
                     }
                 }

--- a/MediaBrowser.Providers/Movies/MovieDbSearch.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbSearch.cs
@@ -5,6 +5,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Logging;
 using MediaBrowser.Model.Providers;
 using MediaBrowser.Model.Serialization;
+using MediaBrowser.Providers.Manager;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -182,7 +183,7 @@ namespace MediaBrowser.Providers.Movies
                             // These dates are always in this exact format
                             if (DateTime.TryParseExact(i.release_date, "yyyy-MM-dd", EnUs, DateTimeStyles.None, out r))
                             {
-                                remoteResult.PremiereDate = r.ToUniversalTime();
+                                remoteResult.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(r, ProviderUtils.GetUsEasternTimeZoneInfo());
                                 remoteResult.ProductionYear = remoteResult.PremiereDate.Value.Year;
                             }
                         }
@@ -239,7 +240,7 @@ namespace MediaBrowser.Providers.Movies
                             // These dates are always in this exact format
                             if (DateTime.TryParseExact(i.first_air_date, "yyyy-MM-dd", EnUs, DateTimeStyles.None, out r))
                             {
-                                remoteResult.PremiereDate = r.ToUniversalTime();
+                                remoteResult.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(r, ProviderUtils.GetUsEasternTimeZoneInfo());
                                 remoteResult.ProductionYear = remoteResult.PremiereDate.Value.Year;
                             }
                         }

--- a/MediaBrowser.Providers/People/MovieDbPersonProvider.cs
+++ b/MediaBrowser.Providers/People/MovieDbPersonProvider.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using CommonIO;
 using MediaBrowser.Model.Logging;
 using MediaBrowser.Model.Net;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.People
 {
@@ -186,12 +187,12 @@ namespace MediaBrowser.Providers.People
 
                 if (DateTime.TryParseExact(info.birthday, "yyyy-MM-dd", new CultureInfo("en-US"), DateTimeStyles.None, out date))
                 {
-                    item.PremiereDate = date.ToUniversalTime();
+                    item.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
                 }
 
                 if (DateTime.TryParseExact(info.deathday, "yyyy-MM-dd", new CultureInfo("en-US"), DateTimeStyles.None, out date))
                 {
-                    item.EndDate = date.ToUniversalTime();
+                    item.EndDate = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
                 }
 
                 item.SetProviderId(MetadataProviders.Tmdb, info.id.ToString(_usCulture));

--- a/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using CommonIO;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.TV
 {
@@ -536,7 +537,7 @@ namespace MediaBrowser.Providers.TV
                                             DateTime date;
                                             if (DateTime.TryParse(val, out date))
                                             {
-                                                airDate = date.ToUniversalTime();
+                                                airDate = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
                                             }
                                         }
 

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using CommonIO;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.TV
 {
@@ -385,7 +386,7 @@ namespace MediaBrowser.Providers.TV
 									if (!string.IsNullOrWhiteSpace (val)) {
 										DateTime date;
 										if (DateTime.TryParse (val, out date)) {
-											date = date.ToUniversalTime ();
+                                            date = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
 
 											return date;
 										}
@@ -663,7 +664,7 @@ namespace MediaBrowser.Providers.TV
 									DateTime date;
 									if (DateTime.TryParse(val, out date))
 									{
-										date = date.ToUniversalTime();
+                                        date = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
 
 										item.PremiereDate = date;
 										item.ProductionYear = date.Year;

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
@@ -22,6 +22,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using CommonIO;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.TV
 {
@@ -699,7 +700,7 @@ namespace MediaBrowser.Providers.TV
                                     DateTime date;
                                     if (DateTime.TryParse(val, out date))
                                     {
-                                        airDate = date.ToUniversalTime();
+                                        airDate = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
                                     }
                                 }
 
@@ -1002,7 +1003,7 @@ namespace MediaBrowser.Providers.TV
                                     DateTime date;
                                     if (DateTime.TryParse(val, out date))
                                     {
-                                        date = date.ToUniversalTime();
+                                        date = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
 
                                         item.PremiereDate = date;
                                         item.ProductionYear = date.Year;


### PR DESCRIPTION
This is a revised approach to fix the problems caused by incorrect
timezone adjustments.
- Let's look at MovieDbProvider, Line 97
- DateTime.TryParse creates a date from the string in the xml
- The next statement ".ToUniversalTime()" converts the datetime from
  local a local datetime to a UTC datetime
- Emby-Server1 is in Timezone UTC+3: If the parsed date is "2016-03-30
  01:00" the converted date would be "2016-03-29 22:00"
- Emby-Server2 is in Timezone UTC-9: If the parsed date is "2016-03-30
  01:00" the converted date would be "2016-03-30 10:00"

As a result, Emby-Server1 would store a different item date than
Emby-Server2. This is incorrect because the UTC date (per definition)
must be a constant value that is independent of any time zone.

The previous pull request suggested to remove all UTC conversions but
was turned down because it would break consistency of the API.
This commit follows a different approach: It assumes a constant timezone
(US EST - Eastern Standard Time) for all dates returned from the
affected metadata providers.
The result: Emby will continue to use UTC based dates, but the
conversion is done consistently.
