### PR TITLE
Avoid frequent Exception

### DIFF
--- a/MediaBrowser.Server.Implementations/Connect/ConnectManager.cs
+++ b/MediaBrowser.Server.Implementations/Connect/ConnectManager.cs
@@ -65,12 +65,11 @@ namespace MediaBrowser.Server.Implementations.Connect
 
                 if (!string.IsNullOrWhiteSpace(address))
                 {
-                    try
+                    Uri newUri;
+
+                    if (Uri.TryCreate(address, UriKind.Absolute, out newUri))
                     {
-                        address = new Uri(address).Host;
-                    }
-                    catch
-                    {
+                        address = newUri.Host;
                     }
                 }
 


### PR DESCRIPTION
That Uri constructor is throwing very often at my site, and avoiding exceptions is usually better than catching, of course.