### PR TITLE
Add support for VAAPI hardware acceleration

### DIFF
--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -309,6 +309,10 @@ namespace MediaBrowser.Api.Playback
                 {
                     return GetAvailableEncoder("h264_omx", defaultEncoder);
                 }
+                if (string.Equals(hwType, "vaapi", StringComparison.OrdinalIgnoreCase))
+                {
+                    return GetAvailableEncoder("h264_vaapi", defaultEncoder);
+                }
             }
 
             return defaultEncoder;
@@ -422,7 +426,8 @@ namespace MediaBrowser.Api.Playback
 
             if (!string.IsNullOrEmpty(state.VideoRequest.Profile))
             {
-                if (!string.Equals(videoCodec, "h264_omx", StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(videoCodec, "h264_omx", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(videoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
                 {
                     // not supported by h264_omx
                     param += " -profile:v " + state.VideoRequest.Profile;
@@ -477,7 +482,8 @@ namespace MediaBrowser.Api.Playback
 
             if (!string.Equals(videoCodec, "h264_omx", StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(videoCodec, "h264_qsv", StringComparison.OrdinalIgnoreCase) &&
-                !string.Equals(videoCodec, "h264_nvenc", StringComparison.OrdinalIgnoreCase))
+                !string.Equals(videoCodec, "h264_nvenc", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(videoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
             {
                 param = "-pix_fmt yuv420p " + param;
             }
@@ -543,59 +549,47 @@ namespace MediaBrowser.Api.Playback
 
             var filters = new List<string>();
 
-            if (state.DeInterlace)
+            if (string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
+            {
+                filters.Add("format=nv12|vaapi");
+                filters.Add("hwupload");
+            }
+            else if (state.DeInterlace && ! string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
             {
                 filters.Add("yadif=0:-1:0");
             }
 
-            // If fixed dimensions were supplied
-            if (request.Width.HasValue && request.Height.HasValue)
+            var scaler = "scale";
+            if (string.Equals (outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
             {
-                var widthParam = request.Width.Value.ToString(UsCulture);
-                var heightParam = request.Height.Value.ToString(UsCulture);
-
-                filters.Add(string.Format("scale=trunc({0}/2)*2:trunc({1}/2)*2", widthParam, heightParam));
+                scaler = "scale_vaapi";
             }
 
-            // If Max dimensions were supplied, for width selects lowest even number between input width and width req size and selects lowest even number from in width*display aspect and requested size
-            else if (request.MaxWidth.HasValue && request.MaxHeight.HasValue)
-            {
-                var maxWidthParam = request.MaxWidth.Value.ToString(UsCulture);
-                var maxHeightParam = request.MaxHeight.Value.ToString(UsCulture);
+            // Given the input dimensions (inputWidth, inputHeight), determine the output dimensions
+            // (outputWidth, outputHeight). The user may request precise output dimensions or maximum
+            // output dimensions. Output dimensions are guaranteed to be even.
+            decimal inputWidth = Convert.ToDecimal(state.VideoStream.Width);
+            decimal inputHeight = Convert.ToDecimal(state.VideoStream.Height);
+            decimal outputWidth = request.Width.HasValue ? Convert.ToDecimal(request.Width.Value) : inputWidth;
+            decimal outputHeight = request.Height.HasValue ? Convert.ToDecimal(request.Height.Value) : inputHeight;
+            decimal maximumWidth = request.MaxWidth.HasValue ? Convert.ToDecimal(request.MaxWidth.Value) : outputWidth;
+            decimal maximumHeight = request.MaxHeight.HasValue ? Convert.ToDecimal(request.MaxHeight.Value) : outputHeight;
 
-                filters.Add(string.Format("scale=trunc(min(max(iw\\,ih*dar)\\,min({0}\\,{1}*dar))/2)*2:trunc(min(max(iw/dar\\,ih)\\,min({0}/dar\\,{1}))/2)*2", maxWidthParam, maxHeightParam));
+            if (outputWidth > maximumWidth || outputHeight > maximumHeight)
+            {
+                var scale = Math.Min(maximumWidth / outputWidth, maximumHeight / outputHeight);
+                outputWidth = Math.Min(maximumWidth, Math.Truncate(outputWidth * scale));
+                outputHeight = Math.Min(maximumHeight, Math.Truncate(outputHeight * scale));
             }
 
-            // If a fixed width was requested
-            else if (request.Width.HasValue)
+            outputWidth = 2 * Math.Truncate(outputWidth / 2);
+            outputHeight = 2 * Math.Truncate(outputHeight / 2);
+
+            Console.WriteLine (string.Format ("Scaling from ({0}, {1}) to ({2}, {3}). Aspect ratio is {4}.", inputWidth, inputHeight, outputWidth, outputHeight, state.VideoStream.AspectRatio));
+
+            if (outputWidth != inputWidth || outputHeight != inputHeight)
             {
-                var widthParam = request.Width.Value.ToString(UsCulture);
-
-                filters.Add(string.Format("scale={0}:trunc(ow/a/2)*2", widthParam));
-            }
-
-            // If a fixed height was requested
-            else if (request.Height.HasValue)
-            {
-                var heightParam = request.Height.Value.ToString(UsCulture);
-
-                filters.Add(string.Format("scale=trunc(oh*a/2)*2:{0}", heightParam));
-            }
-
-            // If a max width was requested
-            else if (request.MaxWidth.HasValue)
-            {
-                var maxWidthParam = request.MaxWidth.Value.ToString(UsCulture);
-
-                filters.Add(string.Format("scale=trunc(min(max(iw\\,ih*dar)\\,{0})/2)*2:trunc(ow/dar/2)*2", maxWidthParam));
-            }
-
-            // If a max height was requested
-            else if (request.MaxHeight.HasValue)
-            {
-                var maxHeightParam = request.MaxHeight.Value.ToString(UsCulture);
-
-                filters.Add(string.Format("scale=trunc(oh*a/2)*2:min(ih\\,{0})", maxHeightParam));
+                filters.Add(string.Format("{0}=w={1}:h={2}", scaler, outputWidth, outputHeight));
             }
 
             var output = string.Empty;
@@ -928,6 +922,12 @@ namespace MediaBrowser.Api.Playback
                     }
                     arg += " -i \"" + state.SubtitleStream.Path + "\"";
                 }
+            }
+
+            if (string.Equals(ApiEntryPoint.Instance.GetEncodingOptions().HardwareAccelerationType, "vaapi", StringComparison.OrdinalIgnoreCase))
+            {
+                arg = "-hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device "
+                        + ApiEntryPoint.Instance.GetEncodingOptions().VaapiDevice + " " + arg;
             }
 
             return arg.Trim();
@@ -2137,7 +2137,7 @@ namespace MediaBrowser.Api.Playback
 
             if (profile == null)
             {
-                // Don't use settings from the default profile. 
+                // Don't use settings from the default profile.
                 // Only use a specific profile if it was requested.
                 return;
             }

--- a/MediaBrowser.Api/Playback/Progressive/VideoService.cs
+++ b/MediaBrowser.Api/Playback/Progressive/VideoService.cs
@@ -149,11 +149,11 @@ namespace MediaBrowser.Api.Playback.Progressive
                 {
                     args += " -copyts -avoid_negative_ts disabled -start_at_zero";
                 }
-                
+
                 return args;
             }
 
-            var keyFrameArg = string.Format(" -force_key_frames expr:gte(t,n_forced*{0})",
+            var keyFrameArg = string.Format(" -force_key_frames \"expr:gte(t,n_forced*{0})\"",
                 5.ToString(UsCulture));
 
             args += keyFrameArg;

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -87,6 +87,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 "h264_nvenc",
                 "h264_qsv",
                 "h264_omx",
+                "h264_vaapi",
                 "ac3"
             };
 

--- a/MediaBrowser.MediaEncoding/Encoder/VideoEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/VideoEncoder.cs
@@ -84,7 +84,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 return args;
             }
 
-            var keyFrameArg = string.Format(" -force_key_frames expr:gte(t,n_forced*{0})",
+            var keyFrameArg = string.Format(" -force_key_frames \"expr:gte(t,n_forced*{0})\"",
                 5.ToString(UsCulture));
 
             args += keyFrameArg;

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -9,6 +9,7 @@ namespace MediaBrowser.Model.Configuration
         public bool EnableThrottling { get; set; }
         public int ThrottleDelaySeconds { get; set; }
         public string HardwareAccelerationType { get; set; }
+        public string VaapiDevice { get; set; }
         public string EncoderAppPath { get; set; }
 
         public EncodingOptions()

--- a/MediaBrowser.Server.Implementations/LiveTv/EmbyTV/EncodedRecorder.cs
+++ b/MediaBrowser.Server.Implementations/LiveTv/EmbyTV/EncodedRecorder.cs
@@ -191,7 +191,7 @@ namespace MediaBrowser.Server.Implementations.LiveTv.EmbyTV
             {
                 var maxBitrate = 25000000;
                 videoArgs = string.Format(
-                        "-codec:v:0 libx264 -force_key_frames expr:gte(t,n_forced*5) {0} -pix_fmt yuv420p -preset superfast -crf 23 -b:v {1} -maxrate {1} -bufsize ({1}*2) -vsync -1 -profile:v high -level 41",
+                        "-codec:v:0 libx264 -force_key_frames \"expr:gte(t,n_forced*5)\" {0} -pix_fmt yuv420p -preset superfast -crf 23 -b:v {1} -maxrate {1} -bufsize ({1}*2) -vsync -1 -profile:v high -level 41",
                         GetOutputSizeParam(),
                         maxBitrate.ToString(CultureInfo.InvariantCulture));
             }


### PR DESCRIPTION
Since ffmpeg 3.1 VAAPI hardware acceleration is supported. This commit adds
support to make use of VAAPI for transcoding. This includes hardware decoding,
scaling and encoding.

Because VAAPI hardware scaling is a bit limited, some parts of scaling were
redone in emby, even though they are supported by the software scaler of
ffmpeg.

As far as I know, VAAPI is a Linux thing. Adavantages over QSV are that it works out of the box if ffmpeg is recent enough (>= 3.1). My experience with this patch is great so far. The part that probably requires discussion is the rewrite of the scaling logic.

I am on holiday for a week now. I wanted to share this though, in order to avoid that someone else spends their valuable time on this. I'll bring this into proper shape for inclusion after my holiday, so sorry, if responding to your criticism takes some time.