### PR TITLE
EpisodeFileOrganizer: Improve error handling (3rd alternate - minmal version)

### DIFF
--- a/MediaBrowser.Server.Implementations/FileOrganization/FileOrganizationService.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/FileOrganizationService.cs
@@ -112,8 +112,13 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
             var organizer = new EpisodeFileOrganizer(this, _config, _fileSystem, _logger, _libraryManager,
                 _libraryMonitor, _providerManager);
 
-            await organizer.OrganizeEpisodeFile(result.OriginalPath, GetAutoOrganizeOptions(), true, CancellationToken.None)
+            var organizeResult = await organizer.OrganizeEpisodeFile(result.OriginalPath, GetAutoOrganizeOptions(), true, CancellationToken.None)
                     .ConfigureAwait(false);
+
+            if (organizeResult.Status != FileSortingStatus.Success)
+            {
+                throw new Exception(result.StatusMessage);
+            }
         }
 
         public Task ClearLog()
@@ -126,7 +131,12 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
             var organizer = new EpisodeFileOrganizer(this, _config, _fileSystem, _logger, _libraryManager,
                 _libraryMonitor, _providerManager);
 
-            await organizer.OrganizeWithCorrection(request, GetAutoOrganizeOptions(), CancellationToken.None).ConfigureAwait(false);
+            var result = await organizer.OrganizeWithCorrection(request, GetAutoOrganizeOptions(), CancellationToken.None).ConfigureAwait(false);
+
+            if (result.Status != FileSortingStatus.Success)
+            {
+                throw new Exception(result.StatusMessage);
+            }
         }
 
         public QueryResult<SmartMatchInfo> GetSmartMatchInfos(FileOrganizationResultQuery query)


### PR DESCRIPTION
**Note: This is another alternate approach to PR #2058**

Previously some methods were just returning null or empty values in case
of encountered errors; as a consequence, the actual reason for failure
was never written to the auto-organize log.
Instead, only a generic message like "Unable to sort xxx because target
path could not be determined." was displayed.

After this change, the actual reason for failure will be saved to the
auto-organize log or displayed in the UI (when completing the organize
dialog).

This information is very important for the user. Examples are "No
permission", "Target folder not available", "Disk full", etc..