### PR TITLE
Provide (unique) ETag value for synced media sources

### DIFF
--- a/MediaBrowser.Server.Implementations/Sync/SyncedMediaSourceProvider.cs
+++ b/MediaBrowser.Server.Implementations/Sync/SyncedMediaSourceProvider.cs
@@ -144,6 +144,10 @@ namespace MediaBrowser.Server.Implementations.Sync
         {
             mediaSource.Id = item.Id;
             mediaSource.SupportsTranscoding = false;
+            if (mediaSource.Protocol == Model.MediaInfo.MediaProtocol.File)
+            {
+                mediaSource.ETag = item.Id;
+            }
         }
 
         public Task CloseMediaSource(string liveStreamId, CancellationToken cancellationToken)


### PR DESCRIPTION
The item.Id is valid for this purpose because it provides a unique identifier for the synced file.

Background: A persistent ETag value enables range-based streaming and seeking of static files being served via http.