### PR TITLE
QuickSeek Feature

### DIFF
--- a/MediaBrowser.Api/ApiEntryPoint.cs
+++ b/MediaBrowser.Api/ApiEntryPoint.cs
@@ -707,9 +707,12 @@ namespace MediaBrowser.Api
         public DateTime LastPingDate { get; set; }
         public int PingTimeout { get; set; }
 
+        public DateTime CreatedAtUtc { get; private set; }
+
         public TranscodingJob(ILogger logger)
         {
             Logger = logger;
+            CreatedAtUtc = DateTime.UtcNow;
         }
 
         public void StopKillTimer()

--- a/MediaBrowser.Api/MediaBrowser.Api.csproj
+++ b/MediaBrowser.Api/MediaBrowser.Api.csproj
@@ -59,6 +59,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Xml" />
     <Reference Include="ServiceStack.Interfaces">
       <HintPath>..\ThirdParty\ServiceStack\ServiceStack.Interfaces.dll</HintPath>
@@ -81,6 +82,7 @@
     <Compile Include="IHasDtoOptions.cs" />
     <Compile Include="Library\ChapterService.cs" />
     <Compile Include="Playback\MediaInfoService.cs" />
+    <Compile Include="Playback\Progressive\ProgressiveRangeWriter.cs" />
     <Compile Include="Playback\TranscodingThrottler.cs" />
     <Compile Include="PlaylistService.cs" />
     <Compile Include="Reports\Activities\ReportActivitiesBuilder.cs" />

--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using CommonIO;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller;
+using MediaBrowser.Model.Configuration;
 
 namespace MediaBrowser.Api.Playback
 {
@@ -1010,6 +1011,24 @@ namespace MediaBrowser.Api.Playback
             return MediaEncoder.GetInputArgument(inputPath, protocol);
         }
 
+        /// <summary>
+        /// Gets the duration argument.
+        /// </summary>
+        /// <param name="state">The state.</param>
+        /// <returns>System.String.</returns>
+        protected string GetOutputDurationArgument(StreamState state)
+        {
+            if (state.UsingQuickSeek)
+            {
+                if (state.RunTimeTicks.HasValue && state.RunTimeTicks.Value > 0)
+                {
+                    return string.Format("-t {0}", MediaEncoder.GetTimeParameter(state.RunTimeTicks.Value));
+                }
+            }
+
+            return string.Empty;
+        }
+
         private async Task AcquireResources(StreamState state, CancellationTokenSource cancellationTokenSource)
         {
             if (state.VideoType == VideoType.Iso && state.IsoType.HasValue && IsoManager.CanMount(state.MediaPath))
@@ -1668,6 +1687,10 @@ namespace MediaBrowser.Api.Playback
                 {
                     request.Tag = val;
                 }
+                else if (i == 30)
+                {
+                    request.TryQuickSeek = string.Equals("true", val, StringComparison.OrdinalIgnoreCase);
+                }
             }
         }
 
@@ -1845,6 +1868,11 @@ namespace MediaBrowser.Api.Playback
                 }
             }
 
+            if (request.TryQuickSeek)
+            {
+                state.UsingQuickSeek = CanUseQuickSeek(ServerConfigurationManager.Configuration, request.Static, state.InputProtocol, state.OutputContainer, state.RunTimeTicks);
+            }
+
             ApplyDeviceProfileSettings(state);
 
             if (videoRequest != null)
@@ -1855,6 +1883,25 @@ namespace MediaBrowser.Api.Playback
             state.OutputFilePath = GetOutputFilePath(state);
 
             return state;
+        }
+
+        public static bool CanUseQuickSeek(ServerConfiguration config, bool isStatic, MediaProtocol protocol, string outputContainer, long? runTimeTicks)
+        {
+            if (config.EnableQuickSeek
+                && !isStatic
+                && !string.IsNullOrWhiteSpace(outputContainer)
+                && protocol == MediaProtocol.File
+                && runTimeTicks.HasValue && runTimeTicks.Value > 0)
+            {
+                var quickSeekContainers = new List<string> { "mkv" };
+
+                if (quickSeekContainers.Contains(outputContainer, StringComparer.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void TryStreamCopy(StreamState state, VideoStreamRequest videoRequest)

--- a/MediaBrowser.Api/Playback/MediaInfoService.cs
+++ b/MediaBrowser.Api/Playback/MediaInfoService.cs
@@ -124,7 +124,7 @@ namespace MediaBrowser.Api.Playback
                 var item = _libraryManager.GetItemById(request.ItemId);
 
                 SetDeviceSpecificData(item, result.MediaSource, profile, authInfo, request.MaxStreamingBitrate,
-                    request.StartTimeTicks ?? 0, result.MediaSource.Id, request.AudioStreamIndex,
+                    request.StartTimeTicks ?? 0, false, result.MediaSource.Id, request.AudioStreamIndex,
                     request.SubtitleStreamIndex, request.PlaySessionId, request.UserId);
             }
             else
@@ -167,7 +167,7 @@ namespace MediaBrowser.Api.Playback
             {
                 var mediaSourceId = request.MediaSourceId;
 
-                SetDeviceSpecificData(request.Id, info, profile, authInfo, request.MaxStreamingBitrate ?? profile.MaxStreamingBitrate, request.StartTimeTicks ?? 0, mediaSourceId, request.AudioStreamIndex, request.SubtitleStreamIndex, request.UserId);
+                SetDeviceSpecificData(request.Id, info, profile, authInfo, request.MaxStreamingBitrate ?? profile.MaxStreamingBitrate, request.StartTimeTicks ?? 0, request.CanQuickSeek ?? false, mediaSourceId, request.AudioStreamIndex, request.SubtitleStreamIndex, request.UserId);
             }
 
             return ToOptimizedResult(info);
@@ -227,6 +227,7 @@ namespace MediaBrowser.Api.Playback
             AuthorizationInfo auth,
             int? maxBitrate,
             long startTimeTicks,
+            bool canQuickSeek,
             string mediaSourceId,
             int? audioStreamIndex,
             int? subtitleStreamIndex,
@@ -236,7 +237,7 @@ namespace MediaBrowser.Api.Playback
 
             foreach (var mediaSource in result.MediaSources)
             {
-                SetDeviceSpecificData(item, mediaSource, profile, auth, maxBitrate, startTimeTicks, mediaSourceId, audioStreamIndex, subtitleStreamIndex, result.PlaySessionId, userId);
+                SetDeviceSpecificData(item, mediaSource, profile, auth, maxBitrate, startTimeTicks, canQuickSeek, mediaSourceId, audioStreamIndex, subtitleStreamIndex, result.PlaySessionId, userId);
             }
 
             SortMediaSources(result, maxBitrate);
@@ -248,6 +249,7 @@ namespace MediaBrowser.Api.Playback
             AuthorizationInfo auth,
             int? maxBitrate,
             long startTimeTicks,
+            bool canQuickSeek,
             string mediaSourceId,
             int? audioStreamIndex,
             int? subtitleStreamIndex,
@@ -367,6 +369,12 @@ namespace MediaBrowser.Api.Playback
                     if (streamInfo.PlayMethod == PlayMethod.Transcode)
                     {
                         streamInfo.StartPositionTicks = startTimeTicks;
+
+                        if (canQuickSeek)
+                        {
+                            streamInfo.TryQuickSeek = BaseStreamingService.CanUseQuickSeek(_config.Configuration, false, mediaSource.Protocol, streamInfo.Container, streamInfo.RunTimeTicks);
+                        }
+
                         mediaSource.TranscodingUrl = streamInfo.ToUrl("-", auth.Token).TrimStart('-');
                         mediaSource.TranscodingContainer = streamInfo.Container;
                         mediaSource.TranscodingSubProtocol = streamInfo.SubProtocol;

--- a/MediaBrowser.Api/Playback/Progressive/ProgressiveRangeWriter.cs
+++ b/MediaBrowser.Api/Playback/Progressive/ProgressiveRangeWriter.cs
@@ -1,0 +1,275 @@
+﻿using MediaBrowser.Model.Logging;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CommonIO;
+using MediaBrowser.Controller.Net;
+using System.Collections.Generic;
+using ServiceStack.Web;
+using System.Net;
+using System.Globalization;
+
+namespace MediaBrowser.Api.Playback.Progressive
+{
+    public class ProgressiveRangeWriter : IAsyncStreamSource, IHttpResult
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly TranscodingJob _job;
+        private readonly ILogger _logger;
+        private readonly string _path;
+        private readonly CancellationToken _cancellationToken;
+        private readonly Dictionary<string, string> _outputHeaders;
+
+        /// <summary>
+        /// The us culture
+        /// </summary>
+        private static readonly CultureInfo UsCulture = new CultureInfo("en-US");
+
+        /// <summary>
+        /// The _requested ranges
+        /// </summary>
+        private List<KeyValuePair<long, long?>> _requestedRanges;
+
+        // 256k
+        private const int BufferSize = 81920;
+
+        private long _bytesWritten = 0;
+        private long? _contentLength = 0;
+
+        public ProgressiveRangeWriter(StreamState state, string rangeHeader, IFileSystem fileSystem, long? contentLength, Dictionary<string, string> outputHeaders, TranscodingJob job, ILogger logger, CancellationToken cancellationToken)
+        {
+            RangeHeader = rangeHeader;
+            _fileSystem = fileSystem;
+            _path = state.OutputFilePath;
+            _contentLength = contentLength;
+            _outputHeaders = outputHeaders;
+            _job = job;
+            _logger = logger;
+            _cancellationToken = cancellationToken;
+
+            var plainFileName = Path.GetFileNameWithoutExtension(_path);
+
+            _outputHeaders["Cache-Control"] = "public, max-age=86400"; // 1 day
+            _outputHeaders["Last-Modified"] = job.CreatedAtUtc.ToString("R", DateTimeFormatInfo.InvariantInfo);
+            _outputHeaders["Expires"] = job.CreatedAtUtc.AddDays(1).ToString("R", DateTimeFormatInfo.InvariantInfo);
+            _outputHeaders["ETag"] = string.Format("\"{0}\"", plainFileName);
+
+            if (state.RunTimeTicks.HasValue)
+            {
+                var duration = TimeSpan.FromTicks(state.RunTimeTicks.Value).TotalSeconds;
+                _outputHeaders["Content-Duration"] = duration.ToString(CultureInfo.InvariantCulture);
+                _outputHeaders["X-Content-Duration"] = duration.ToString(CultureInfo.InvariantCulture);
+            }
+
+            SetRangeValues();
+            StatusCode = HttpStatusCode.PartialContent;
+
+            Cookies = new List<Cookie>();
+            ContentType = outputHeaders["Content-Type"];
+        }
+
+        public Func<IDisposable> ResultScope { get; set; }
+        public List<Cookie> Cookies { get; private set; }
+
+        public IDictionary<string, string> Options
+        {
+            get
+            {
+                return _outputHeaders;
+            }
+        }
+
+        public Dictionary<string, string> Headers
+        {
+            get
+            {
+                return _outputHeaders;
+            }
+        }
+
+        public string ContentType { get; set; }
+
+        public IRequest RequestContext { get; set; }
+
+        public object Response { get; set; }
+
+        public IContentTypeWriter ResponseFilter { get; set; }
+
+        public int Status { get; set; }
+
+        public HttpStatusCode StatusCode
+        {
+            get { return (HttpStatusCode)Status; }
+            set { Status = (int)value; }
+        }
+
+        public string StatusDescription { get; set; }
+
+        public int PaddingLength { get; set; }
+
+        private string RangeHeader { get; set; }
+
+        private long RangeStart { get; set; }
+        private long? RangeEnd { get; set; }
+        private long? RangeLength { get; set; }
+
+        /// <summary>
+        /// Gets the requested ranges.
+        /// </summary>
+        /// <value>The requested ranges.</value>
+        protected List<KeyValuePair<long, long?>> RequestedRanges
+        {
+            get
+            {
+                if (_requestedRanges == null)
+                {
+                    _requestedRanges = new List<KeyValuePair<long, long?>>();
+
+                    // Example: bytes=0-,32-63
+                    var ranges = RangeHeader.Split('=')[1].Split(',');
+
+                    foreach (var range in ranges)
+                    {
+                        var vals = range.Split('-');
+
+                        long start = 0;
+                        long? end = null;
+
+                        if (!string.IsNullOrEmpty(vals[0]))
+                        {
+                            start = long.Parse(vals[0], UsCulture);
+                        }
+                        if (!string.IsNullOrEmpty(vals[1]))
+                        {
+                            end = long.Parse(vals[1], UsCulture);
+                        }
+
+                        _requestedRanges.Add(new KeyValuePair<long, long?>(start, end));
+                    }
+                }
+
+                return _requestedRanges;
+            }
+        }
+
+        public async Task WriteToAsync(Stream outputStream)
+        {
+            if (StatusCode == HttpStatusCode.PartialContent)
+            {
+                try
+                {
+                    var eofCount = 0;
+
+                    using (var fs = _fileSystem.GetFileStream(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, true))
+                    {
+                        if (RangeStart > 0)
+                        {
+                            fs.Position = RangeStart;
+                        }
+
+                        while (eofCount < 15)
+                        {
+                            var bytesRead = await CopyToAsyncInternal(fs, outputStream, BufferSize, _cancellationToken).ConfigureAwait(false);
+
+                            //var position = fs.Position;
+                            //_logger.Debug("Streamed {0} bytes to position {1} from file {2}", bytesRead, position, path);
+
+                            if (bytesRead == 0)
+                            {
+                                if (_job == null || _job.HasExited)
+                                {
+                                    eofCount++;
+                                }
+                                await Task.Delay(100, _cancellationToken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                eofCount = 0;
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    if (_job != null)
+                    {
+                        ApiEntryPoint.Instance.OnTranscodeEndRequest(_job);
+                    }
+                }
+            }
+        }
+
+        private async Task<int> CopyToAsyncInternal(Stream source, Stream destination, Int32 bufferSize, CancellationToken cancellationToken)
+        {
+            byte[] buffer = new byte[bufferSize];
+            int bytesRead;
+            int totalBytesRead = 0;
+
+            while ((bytesRead = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) != 0)
+            {
+                await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+
+                _bytesWritten += bytesRead;
+                totalBytesRead += bytesRead;
+
+                if (_job != null)
+                {
+                    _job.BytesDownloaded = Math.Max(_job.BytesDownloaded ?? _bytesWritten, _bytesWritten);
+                }
+            }
+
+            return totalBytesRead;
+        }
+
+        /// <summary>
+        /// Sets the range values.
+        /// </summary>
+        private void SetRangeValues()
+        {
+            if (RequestedRanges.Count != 1)
+            {
+                StatusCode = HttpStatusCode.RequestedRangeNotSatisfiable;
+                return;
+            }
+
+            var requestedRange = RequestedRanges[0];
+
+            if (_job.HasExited && _job.CompletionPercentage.HasValue && _job.CompletionPercentage.Value > 99.0)
+            {
+                var fileInfo = _fileSystem.GetFileInfo(_path);
+                _contentLength = fileInfo.Length;
+            }
+            ////else if (_job.BitRate.HasValue)
+            ////{
+
+            ////}
+
+            RangeStart = requestedRange.Key;
+
+            if (requestedRange.Value.HasValue)
+            {
+                RangeEnd = requestedRange.Value.Value;
+            }
+            else if (!_contentLength.HasValue)
+            {
+                // In case we don't know the total length we must still return a defined range
+                // so we return what we got so far
+                var fileInfo = _fileSystem.GetFileInfo(_path);
+                RangeEnd = fileInfo.Length - 1;
+            }
+            else
+            {
+                RangeEnd = _contentLength.Value - 1;
+            }
+
+            RangeLength = RangeEnd - RangeStart + 1;
+
+            string totalLength = _contentLength.HasValue ? _contentLength.Value.ToString(UsCulture) : "*";
+
+            // Content-Length is the length of what we're serving, not the original content
+            _outputHeaders["Content-Length"] = RangeLength.Value.ToString(UsCulture);
+            _outputHeaders["Content-Range"] = string.Format("bytes {0}-{1}/{2}", RangeStart, RangeEnd, totalLength);
+        }
+    }
+}

--- a/MediaBrowser.Api/Playback/Progressive/VideoService.cs
+++ b/MediaBrowser.Api/Playback/Progressive/VideoService.cs
@@ -110,13 +110,14 @@ namespace MediaBrowser.Api.Playback.Progressive
 
             var inputModifier = GetInputModifier(state);
 
-            return string.Format("{0} {1}{2} {3} {4} -map_metadata -1 -threads {5} {6}{7} -y \"{8}\"",
+            return string.Format("{0} {1}{2} {3} {4} -map_metadata -1 -threads {5} {6} {7}{8} -y \"{9}\"",
                 inputModifier,
                 GetInputArgument(state),
                 keyFrame,
                 GetMapArgs(state),
                 GetVideoArguments(state, videoCodec),
                 threads,
+                GetOutputDurationArgument(state),
                 GetAudioArguments(state),
                 format,
                 outputPath

--- a/MediaBrowser.Api/Playback/StreamRequest.cs
+++ b/MediaBrowser.Api/Playback/StreamRequest.cs
@@ -75,6 +75,7 @@ namespace MediaBrowser.Api.Playback
         public string PlaySessionId { get; set; }
         public string LiveStreamId { get; set; }
         public string Tag { get; set; }
+        public bool TryQuickSeek { get; set; }
     }
 
     public class VideoStreamRequest : StreamRequest

--- a/MediaBrowser.Api/Playback/StreamState.cs
+++ b/MediaBrowser.Api/Playback/StreamState.cs
@@ -140,6 +140,8 @@ namespace MediaBrowser.Api.Playback
 
         public long? EncodingDurationTicks { get; set; }
 
+        public bool UsingQuickSeek { get; set; }
+
         public string GetMimeType(string outputPath)
         {
             if (!string.IsNullOrEmpty(MimeType))

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -204,6 +204,7 @@ namespace MediaBrowser.Model.Configuration
         public bool DisplayCollectionsView { get; set; }
         public string[] LocalNetworkAddresses { get; set; }
         public string[] CodecsUsed { get; set; }
+        public bool EnableQuickSeek { get; set; }
         public bool EnableChannelView { get; set; }
         public bool EnableExternalContentInSuggestions { get; set; }
 

--- a/MediaBrowser.Model/Dlna/StreamInfo.cs
+++ b/MediaBrowser.Model/Dlna/StreamInfo.cs
@@ -78,6 +78,8 @@ namespace MediaBrowser.Model.Dlna
         public string PlaySessionId { get; set; }
         public List<MediaSourceInfo> AllMediaSources { get; set; }
 
+        public bool TryQuickSeek { get; set; }
+
         public string MediaSourceId
         {
             get
@@ -251,6 +253,7 @@ namespace MediaBrowser.Model.Dlna
             list.Add(new NameValuePair("EnableSubtitlesInManifest", item.EnableSubtitlesInManifest.ToString().ToLower()));
 
             list.Add(new NameValuePair("Tag", item.MediaSource.ETag ?? string.Empty));
+            list.Add(new NameValuePair("TryQuickSeek",  item.TryQuickSeek.ToString().ToLower()));
 
             return list;
         }

--- a/MediaBrowser.Model/MediaInfo/PlaybackInfoRequest.cs
+++ b/MediaBrowser.Model/MediaInfo/PlaybackInfoRequest.cs
@@ -20,6 +20,8 @@ namespace MediaBrowser.Model.MediaInfo
 
         public string LiveStreamId { get; set; }
         
+        public bool? CanQuickSeek { get; set; }
+
         public DeviceProfile DeviceProfile { get; set; }
     }
 }

--- a/MediaBrowser.Server.Implementations/HttpServer/AsyncStreamWriterEx.cs
+++ b/MediaBrowser.Server.Implementations/HttpServer/AsyncStreamWriterEx.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using ServiceStack;
+using ServiceStack.Web;
+using MediaBrowser.Controller.Net;
+
+namespace MediaBrowser.Server.Implementations.HttpServer
+{
+    public class AsyncStreamWriterEx : AsyncStreamWriter, IHttpResult
+    {
+        /// <summary>
+        /// Gets or sets the source stream.
+        /// </summary>
+        /// <value>The source stream.</value>
+        private IAsyncStreamSource _source;
+
+        private IHttpResult _httpResult;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncStreamWriter" /> class.
+        /// </summary>
+        public AsyncStreamWriterEx(IAsyncStreamSource source) : base(source)
+        {
+            _httpResult = source as IHttpResult;
+
+            if (_httpResult == null)
+            {
+                throw new ArgumentException("AsyncStreamWriterEx: source does not implement IHttpResult");
+            }
+
+            _source = source;
+        }
+
+        public string ContentType
+        {
+            get
+            {
+                return _httpResult.ContentType;
+            }
+            set
+            {
+                _httpResult.ContentType = value;
+            }
+        }
+
+        public List<System.Net.Cookie> Cookies
+        {
+            get { return _httpResult.Cookies; }
+        }
+
+        public Dictionary<string, string> Headers
+        {
+            get { return _httpResult.Headers; }
+        }
+
+        public int PaddingLength
+        {
+            get
+            {
+                return _httpResult.PaddingLength;
+            }
+            set
+            {
+                _httpResult.PaddingLength = value;
+            }
+        }
+
+        public IRequest RequestContext
+        {
+            get
+            {
+                return _httpResult.RequestContext;
+            }
+            set
+            {
+                _httpResult.RequestContext = value;
+            }
+        }
+
+        public object Response
+        {
+            get
+            {
+                return _httpResult.Response;
+            }
+            set
+            {
+                _httpResult.Response = value;
+            }
+        }
+
+        public IContentTypeWriter ResponseFilter
+        {
+            get
+            {
+                return _httpResult.ResponseFilter;
+            }
+            set
+            {
+                _httpResult.ResponseFilter = value;
+            }
+        }
+
+        public Func<IDisposable> ResultScope
+        {
+            get
+            {
+                return _httpResult.ResultScope;
+            }
+            set
+            {
+                _httpResult.ResultScope = value;
+            }
+        }
+
+        public int Status
+        {
+            get
+            {
+                return _httpResult.Status;
+            }
+            set
+            {
+                _httpResult.Status = value;
+            }
+        }
+
+        public System.Net.HttpStatusCode StatusCode
+        {
+            get
+            {
+                return _httpResult.StatusCode;
+            }
+            set
+            {
+                _httpResult.StatusCode = value;
+            }
+        }
+
+        public string StatusDescription
+        {
+            get
+            {
+                return _httpResult.StatusDescription;
+            }
+            set
+            {
+                _httpResult.StatusDescription = value;
+            }
+        }
+    }
+}

--- a/MediaBrowser.Server.Implementations/HttpServer/HttpResultFactory.cs
+++ b/MediaBrowser.Server.Implementations/HttpServer/HttpResultFactory.cs
@@ -706,6 +706,11 @@ namespace MediaBrowser.Server.Implementations.HttpServer
 
         public object GetAsyncStreamWriter(IAsyncStreamSource streamSource)
         {
+            if (streamSource as IHttpResult != null)
+            {
+                return new AsyncStreamWriterEx(streamSource);
+            }
+
             return new AsyncStreamWriter(streamSource);
         }
     }

--- a/MediaBrowser.Server.Implementations/MediaBrowser.Server.Implementations.csproj
+++ b/MediaBrowser.Server.Implementations/MediaBrowser.Server.Implementations.csproj
@@ -157,6 +157,7 @@
     <Compile Include="EntryPoints\ServerEventNotifier.cs" />
     <Compile Include="EntryPoints\UserDataChangeNotifier.cs" />
     <Compile Include="FileOrganization\OrganizerScheduledTask.cs" />
+    <Compile Include="HttpServer\AsyncStreamWriterEx.cs" />
     <Compile Include="HttpServer\AsyncStreamWriter.cs" />
     <Compile Include="HttpServer\IHttpListener.cs" />
     <Compile Include="HttpServer\Security\AuthorizationContext.cs" />

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/htmlmediarenderer.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/htmlmediarenderer.js
@@ -259,6 +259,60 @@
             return null;
         };
 
+        self.isInSeekableRange = function (time) {
+
+            var timeSeconds = time / 1000;
+
+            if (mediaElement) {
+
+                var seekable = mediaElement.seekable;
+ 
+                for (var i = 0, len = seekable.length; i < len; i++) {
+
+                    if (timeSeconds >= seekable.start(i) && timeSeconds <= seekable.end(i)) {
+                        console.log('htmlmediarenderer.isInSeekableRange: returned  true');
+                        return true;
+                    }
+                }
+
+                console.log('htmlmediarenderer.isInSeekableRange: returned  false');
+
+                return false;
+            }
+
+            return false;
+        };
+
+        self.isInBufferedRange = function (time) {
+
+            var timeSeconds = time / 1000;
+
+            if (timeSeconds == 0) {
+                // Sometimes, in Chrome the buffered.start is like 0.4 instead of 0, so add 1s tolerance
+                timeSeconds = 1;
+            }
+
+            if (mediaElement) {
+
+                var buffered = mediaElement.buffered;
+ 
+                var minRange = Number.MAX_VALUE;
+                var maxRange = 0;
+ 
+                for (var i = 0, len = buffered.length; i < len; i++) {
+
+                    minRange = Math.min(minRange, buffered.start(i));
+                    maxRange = Math.max(maxRange, buffered.end(i));
+                }
+
+                console.log('htmlmediarenderer.isInBufferedRange: Start: ' + minRange + ' End: ' + maxRange + '    Value: ' + timeSeconds);
+
+                return (timeSeconds >= minRange) && (timeSeconds < maxRange);
+            }
+
+            return false;
+        };
+
         self.stop = function () {
 
             destroyCustomTrack(mediaElement);

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/mediacontroller.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/mediacontroller.js
@@ -878,7 +878,7 @@
 
         }
 
-        self.getPlaybackInfo = function (itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId) {
+        self.getPlaybackInfo = function (itemId, deviceProfile, startPosition, canQuickSeek, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId) {
 
             return new Promise(function (resolve, reject) {
 
@@ -897,21 +897,21 @@
                                 return;
                             }
 
-                            getPlaybackInfoWithoutLocalMediaSource(itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId, resolve, reject);
+                            getPlaybackInfoWithoutLocalMediaSource(itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId, canQuickSeek, resolve, reject);
                         });
                         return;
                     }
 
-                    getPlaybackInfoWithoutLocalMediaSource(itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId, resolve, reject);
+                    getPlaybackInfoWithoutLocalMediaSource(itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId, canQuickSeek, resolve, reject);
                 });
             });
         }
 
-        function getPlaybackInfoWithoutLocalMediaSource(itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId, resolve, reject) {
-            self.getPlaybackInfoInternal(itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId).then(resolve, reject);
+        function getPlaybackInfoWithoutLocalMediaSource(itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId, canQuickSeek, resolve, reject) {
+            self.getPlaybackInfoInternal(itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId, canQuickSeek).then(resolve, reject);
         }
 
-        self.getPlaybackInfoInternal = function (itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId) {
+        self.getPlaybackInfoInternal = function (itemId, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex, liveStreamId, canQuickSeek) {
 
             var postData = {
                 DeviceProfile: deviceProfile
@@ -933,6 +933,9 @@
             }
             if (liveStreamId) {
                 query.LiveStreamId = liveStreamId;
+            }
+            if (canQuickSeek) {
+                query.CanQuickSeek = canQuickSeek;
             }
 
             return ApiClient.ajax({

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/mediaplayer-video.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/mediaplayer-video.js
@@ -33,13 +33,6 @@
             }
         };
 
-        function setClass(elems, method, className) {
-
-            for (var i = 0, length = elems.length; i < length; i++) {
-                elems[i].classList[method](className);
-            }
-        }
-
         self.resetEnhancements = function () {
 
             if (!initComplete) {
@@ -56,15 +49,15 @@
             videoPlayerElement.classList.remove('fullscreenVideo');
             videoPlayerElement.classList.remove('idlePlayer');
 
-            setClass(document.querySelectorAll('.hiddenOnIdle'), 'remove', 'inactive');
+            self.removeClass('hiddenOnIdle', 'inactive');
             var video = videoPlayerElement.querySelector('video');
             if (video) {
                 video.parentNode.removeChild(video);
             }
 
-            document.querySelector('.mediaButton.infoButton').classList.remove('active');
-            document.querySelector('.videoControls .nowPlayingInfo').classList.add('hide');
-            document.querySelector('.videoControls').classList.add('hiddenOnIdle');
+            self.removeClass('.mediaButton.infoButton', 'active');
+            self.addClass('.videoControls .nowPlayingInfo', 'hide');
+            self.addClass('.videoControls', 'hiddenOnIdle');
         };
 
         self.exitFullScreen = function () {
@@ -85,6 +78,24 @@
         self.isFullScreen = function () {
             return document.fullscreen || document.mozFullScreen || document.webkitIsFullScreen || document.msFullscreenElement ? true : false;
         };
+
+        self.addClass = function (selector, className) {
+
+            var elems = document.querySelectorAll(selector);
+
+            for (var i = 0, length = elems.length; i < length; i++) {
+                elems[i].classList.add(className);
+            }
+        }
+
+        self.removeClass = function (selector, className) {
+
+            var elems = document.querySelectorAll(selector);
+
+            for (var i = 0, length = elems.length; i < length; i++) {
+                elems[i].classList.remove(className);
+            }
+        }
 
         self.showSubtitleMenu = function () {
 
@@ -423,7 +434,7 @@
                         selectedNowPlayingTabButton.classList.remove('selectedNowPlayingTabButton');
                     }
                     this.classList.add('selectedNowPlayingTabButton');
-                    setClass(document.querySelectorAll('.nowPlayingTab'), 'add', 'hide');
+                    self.addClass('.nowPlayingTab', 'hiddenOnIdlehide');
                     document.querySelector('.' + this.getAttribute('data-tab')).classList.remove('hide');
                 }
             }
@@ -729,8 +740,10 @@
             html += '<div class="videoTopControlsLogo"></div>';
             html += '<div class="videoAdvancedControls">';
 
-            html += '<button is="paper-icon-button-light" class="previousTrackButton mediaButton videoTrackControl hide autoSize" onclick="MediaPlayer.previousTrack();"><i class="md-icon">skip_previous</i></button>';
-            html += '<button is="paper-icon-button-light" class="nextTrackButton mediaButton videoTrackControl hide autoSize" onclick="MediaPlayer.nextTrack();"><i class="md-icon">skip_next</i></button>';
+            html += '<button is="paper-icon-button-light" class="previousTrackButton mediaButton videoTrackControl hide autoSize" onclick="MediaPlayer.previousTrack();"><i class="md-icon">chevron_left</i></button>';
+            html += '<button is="paper-icon-button-light" class="skipBackButton mediaButton videoSkipControl hide autoSize" onclick="MediaPlayer.skipBackward();"><i class="md-icon">skip_previous</i></button>';
+            html += '<button is="paper-icon-button-light" class="skipForwardButton mediaButton videoSkipControl hide autoSize" onclick="MediaPlayer.skipForward();"><i class="md-icon">skip_next</i></button>';
+            html += '<button is="paper-icon-button-light" class="nextTrackButton mediaButton videoTrackControl hide autoSize" onclick="MediaPlayer.nextTrack();"><i class="md-icon">chevron_right</i></button>';
 
             // Embedding onclicks due to issues not firing in cordova safari
             html += '<button is="paper-icon-button-light" class="mediaButton videoAudioButton autoSize" onclick="MediaPlayer.showAudioTracksFlyout();"><i class="md-icon">audiotrack</i></button>';
@@ -753,10 +766,12 @@
             html += '</div>'; // guide
 
             html += '<div class="videoControlButtons">';
-            html += '<button is="paper-icon-button-light" class="previousTrackButton mediaButton videoTrackControl hide autoSize" onclick="MediaPlayer.previousTrack();"><i class="md-icon">skip_previous</i></button>';
+            html += '<button is="paper-icon-button-light" class="previousTrackButton mediaButton videoTrackControl hide autoSize" onclick="MediaPlayer.previousTrack();"><i class="md-icon">chevron_left</i></button>';
+            html += '<button is="paper-icon-button-light" class="skipBackButton mediaButton videoSkipControl hide autoSize" onclick="MediaPlayer.skipBackward();"><i class="md-icon">skip_previous</i></button>';
             html += '<button is="paper-icon-button-light" id="video-playButton" class="mediaButton unpauseButton autoSize" onclick="MediaPlayer.unpause();"><i class="md-icon">play_arrow</i></button>';
             html += '<button is="paper-icon-button-light" id="video-pauseButton" class="mediaButton pauseButton autoSize" onclick="MediaPlayer.pause();"><i class="md-icon">pause</i></button>';
-            html += '<button is="paper-icon-button-light" class="nextTrackButton mediaButton videoTrackControl hide autoSize" onclick="MediaPlayer.nextTrack();"><i class="md-icon">skip_next</i></button>';
+            html += '<button is="paper-icon-button-light" class="skipForwardButton mediaButton videoSkipControl hide autoSize" onclick="MediaPlayer.skipForward();"><i class="md-icon">skip_next</i></button>';
+            html += '<button is="paper-icon-button-light" class="nextTrackButton mediaButton videoTrackControl hide autoSize" onclick="MediaPlayer.nextTrack();"><i class="md-icon">chevron_right</i></button>';
 
             html += '<div class="sliderContainer videoPositionSliderContainer" style="display:inline-flex;margin-right:2em;">';
             html += '<input type="range" is="emby-slider" pin step=".1" min="0" max="100" value="0" class="videoPositionSlider" />';
@@ -839,7 +854,7 @@
             }
 
             if (idleState == true) {
-                setClass(document.querySelectorAll('.hiddenOnIdle'), 'remove', 'inactive');
+                self.removeClass('.hiddenOnIdle', 'inactive');
                 document.querySelector('#videoPlayer').classList.remove('idlePlayer');
             }
 
@@ -847,7 +862,7 @@
 
             idleHandlerTimeout = window.setTimeout(function () {
                 idleState = true;
-                setClass(document.querySelectorAll('.hiddenOnIdle'), 'add', 'inactive');
+                self.addClass('.hiddenOnIdle', 'inactive');
                 document.querySelector('#videoPlayer').classList.add('idlePlayer');
             }, 3500);
         }
@@ -1110,8 +1125,11 @@
             document.querySelector('#video-playButton').classList.add('hide');
             document.querySelector('#video-pauseButton').classList.remove('hide');
 
-            document.querySelector('.videoTrackControl').classList.add('hide');
+            self.addClass('.videoTrackControl', 'hide');
             document.querySelector('.videoQualityButton').classList.remove('hide');
+
+            // For testing: Always display skip buttons
+            self.removeClass('.videoSkipControl', 'hide');
 
             if (mediaStreams.filter(function (s) {
                 return s.Type == "Audio";
@@ -1307,7 +1325,7 @@
             }
 
             if (length < 2) {
-                document.querySelector('.videoTrackControl').classList.add('hide');
+                self.addClass('.videoTrackControl', 'hide');
                 return;
             }
 


### PR DESCRIPTION
Here comes the "QuickSeek" feature for Emby!
## Summary

The QuickSeek feature allows fast seeking in videos served by Emby that are remuxed or transcoded on-the-fly
## Instructions

To get this (experimental feature) to work, a number of specific requirements have to be met:
- A recent version of ffmpeg must be used and configured (I'm using 20160815)
- The feature must be activated in ServerConfiguration (config/system.xml); <EnableQuickSeek>true</EnableQuickSeek>
- Client browser must be Chrome connecting to the default web interface
- Video container mus be mkv
- Remuxing or transcoding must be used
