### PR TITLE
Add method for adding raw http handlers

### DIFF
--- a/MediaBrowser.Controller/MediaBrowser.Controller.csproj
+++ b/MediaBrowser.Controller/MediaBrowser.Controller.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Net\IAsyncStreamSource.cs" />
     <Compile Include="Net\IHasResultFactory.cs" />
     <Compile Include="Net\IHasSession.cs" />
+    <Compile Include="Net\IHttpRawHandler.cs" />
     <Compile Include="Net\IHttpResultFactory.cs" />
     <Compile Include="Net\IHttpServer.cs" />
     <Compile Include="Net\IRestfulService.cs" />

--- a/MediaBrowser.Controller/Net/IHttpRawHandler.cs
+++ b/MediaBrowser.Controller/Net/IHttpRawHandler.cs
@@ -1,0 +1,16 @@
+﻿using MediaBrowser.Controller.Net;
+using ServiceStack.Web;
+using System;
+
+namespace MediaBrowser.Controller.Net
+{
+    public interface IHttpRawHandler
+    {
+        /// <summary>
+        /// Processes the raw request.
+        /// </summary>
+        /// <param name="request">The HTTP request.</param>
+        /// <returns></returns>
+        Action<IRequest, IResponse> ProcessRawRequest(IHttpRequest request);
+    }
+}

--- a/MediaBrowser.Controller/Net/IHttpServer.cs
+++ b/MediaBrowser.Controller/Net/IHttpServer.cs
@@ -52,5 +52,7 @@ namespace MediaBrowser.Controller.Net
         /// If set, all requests will respond with this message
         /// </summary>
         string GlobalResponse { get; set; }
+
+        void AddHttpRawHandler(IHttpRawHandler handler);
     }
 }


### PR DESCRIPTION
This allows plugins to serve static content from disk or from embedded
resources like (but not limited to) html, js, css...