### PR TITLE
Remove zerolatency from ffmpeg h264.

### DIFF
--- a/MediaBrowser.Api/Playback/BaseStreamingService.cs
+++ b/MediaBrowser.Api/Playback/BaseStreamingService.cs
@@ -389,8 +389,6 @@ namespace MediaBrowser.Api.Playback
                 {
                     param += " -crf 23";
                 }
-
-                param += " -tune zerolatency";
             }
 
             else if (string.Equals(videoEncoder, "libx265", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Even if zerolatency sounds good for streaming video, it's purpose is real time video such as video conference, webcam etc.

zerolarency greatly reduce video encoding performance (by as much as a factor of 2), hurting picture quality and compression by limiting how much processing can be done in favor of low latency.