### PR TITLE
fix wrong start url in manifest.json

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/manifest.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "Emby",
   "short_name": "Emby",
-  "start_url": "index.html",
+  "start_url": "web/index.html",
   "description": "The open media solution.",
   "lang": "en-US",
   "related_applications": [


### PR DESCRIPTION
The `start_url` was wrong in the manifest.json, causing a 404 error on Android when adding Emby to home screen.