### PR TITLE
Do not update wan.dat if WAN IP has not changed

### DIFF
--- a/Emby.Server.Implementations/Connect/ConnectEntryPoint.cs
+++ b/Emby.Server.Implementations/Connect/ConnectEntryPoint.cs
@@ -18,6 +18,7 @@ namespace Emby.Server.Implementations.Connect
     public class ConnectEntryPoint : IServerEntryPoint
     {
         private ITimer _timer;
+        private IpAddressInfo _cachedIpAddress;
         private readonly IHttpClient _httpClient;
         private readonly IApplicationPaths _appPaths;
         private readonly ILogger _logger;
@@ -151,6 +152,12 @@ namespace Emby.Server.Implementations.Connect
 
         private void CacheAddress(IpAddressInfo address)
         {
+            if (_cachedIpAddress != null && _cachedIpAddress.Equals(address))
+            {
+                // no need to update the file if the address has not changed
+                return;
+            }
+
             var path = CacheFilePath;
 
             try
@@ -164,6 +171,7 @@ namespace Emby.Server.Implementations.Connect
             try
             {
                 _fileSystem.WriteAllText(path, _encryption.EncryptString(address.ToString()), Encoding.UTF8);
+                _cachedIpAddress = address;
             }
             catch (Exception ex)
             {
@@ -184,6 +192,7 @@ namespace Emby.Server.Implementations.Connect
 
                 if (_networkManager.TryParseIpAddress(endpoint, out ipAddress))
                 {
+                    _cachedIpAddress = ipAddress;
                     ((ConnectManager)_connectManager).OnWanAddressResolved(ipAddress);
                 }
             }


### PR DESCRIPTION
In an effort to reduce unnecessary disk IO so that Synology products are able to hibernate the disk drives (or for the disk drives to not be woken up by disk IO), this PR updates the WAN IP detection code in `ConnectEntryPoint` to not write out the WAN IP address to disk if it has not changed. The WAN IP detection still happens hourly as before, the only difference is that the **wan.dat** file is not updated unnecessarily if the IP address has not changed since the last check.

In the existing code, `ConnectEntryPoint` also calls `ConnectManager.OnWanAddressResolved` hourly when the WAN IP is resolved. That ultimately causes further disk IO to the **connect.txt** file due to writing out of `ConnectData`. This further writing to **connnect.txt** is however not addressed in the single commit of this PR because there are a number of options for resolving this which need to be discussed, namely:
1. Do not call `ConnectManager.OnWanAddressResolved` if the WAN IP has not changed, which means that the `ConnectManager` class will get called much less frequently, or
2. Implement logic similar to the `ConnectEntryPoint` fix above so that the **connect.txt** file is not updated if the `ConnectData` has not changed, possibly ignoring the `LastAuthorizationsRefresh` proprerty.

The PR is ready to be merged for the **wan.dat** fix, but if you would like to address **connect.txt** in this same PR, then the PR can be amended. Otherwise a new PR can be opened to address the latter.