### PR TITLE
Update BaseNfoParser to handle user defined IExternalIds

### DIFF
--- a/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
+++ b/MediaBrowser.XbmcMetadata/Parsers/BaseNfoParser.cs
@@ -964,7 +964,19 @@ namespace MediaBrowser.XbmcMetadata.Parsers
                     }
 
                 default:
-                    reader.Skip();
+                    var providerId = reader.Name;
+                    if (_validProviderIds.ContainsKey(providerId))
+                    {
+                        var id = reader.ReadElementContentAsString();
+                        if (!string.IsNullOrWhiteSpace(id))
+                        {
+                            item.SetProviderId(_validProviderIds[providerId], id);
+                        }
+                    }
+                    else
+                    {
+                        reader.Skip();
+                    }
                     break;
             }
         }


### PR DESCRIPTION
I have a plugin that implements an IExternalId. The BaseNfoSaver saves this ID but the BaseNfoParser does not read the saved ID.
e.g. this is written by BaseNfoSaver but BaseNfoParser ignores the mymovieid element

```
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<movie>
  <title>My Movie Title</title>
  <mymovieid>movie654321</mymovieid>
......
</movie>
```

This PR adds the code from BaseItemXmlParser that handles processing user defined IExternalIds to BaseNfoParser.   