### PR TITLE
Update NfoSavers so they don't duplicate user defined IExternalIds

### DIFF
--- a/MediaBrowser.XbmcMetadata/Savers/AlbumNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/AlbumNfoSaver.cs
@@ -85,15 +85,15 @@ namespace MediaBrowser.XbmcMetadata.Savers
             }
         }
 
-        protected override List<string> GetTagsUsed()
+        protected override List<string> GetTagsUsed(IHasMetadata item)
         {
-            var list = new List<string>
+            var list = base.GetTagsUsed(item);
+            list.AddRange(new string[]
             {
-                    "track",
-                    "artist",
-                    "albumartist"
-            };
-
+                "track",
+                "artist",
+                "albumartist"
+            });
             return list;
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/ArtistNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/ArtistNfoSaver.cs
@@ -79,14 +79,14 @@ namespace MediaBrowser.XbmcMetadata.Savers
             }
         }
 
-        protected override List<string> GetTagsUsed()
+        protected override List<string> GetTagsUsed(IHasMetadata item)
         {
-            var list = new List<string>
+            var list = base.GetTagsUsed(item);
+            list.AddRange(new string[]
             {
-                    "album",
-                    "disbanded"
-            };
-
+                "album",
+                "disbanded"
+            });
             return list;
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/BaseNfoSaver.cs
@@ -183,9 +183,18 @@ namespace MediaBrowser.XbmcMetadata.Savers
         /// <returns><c>true</c> if [is enabled for] [the specified item]; otherwise, <c>false</c>.</returns>
         public abstract bool IsEnabledFor(IHasMetadata item, ItemUpdateType updateType);
 
-        protected virtual List<string> GetTagsUsed()
+        protected virtual List<string> GetTagsUsed(IHasMetadata item)
         {
-            return new List<string>();
+            var list = new List<string>();
+            foreach (var providerKey in item.ProviderIds.Keys)
+            {
+                var providerIdTagName = GetTagForProviderKey(providerKey);
+                if (!CommonTags.ContainsKey(providerIdTagName))
+                {
+                    list.Add(providerIdTagName);
+                }
+            }
+            return list;
         }
 
         public void Save(IHasMetadata item, CancellationToken cancellationToken)
@@ -271,7 +280,7 @@ namespace MediaBrowser.XbmcMetadata.Savers
                     AddMediaInfo(hasMediaSources, writer);
                 }
 
-                var tagsUsed = GetTagsUsed();
+                var tagsUsed = GetTagsUsed(item);
 
                 try
                 {
@@ -834,7 +843,8 @@ namespace MediaBrowser.XbmcMetadata.Savers
                     var providerId = item.ProviderIds[providerKey];
                     if (!string.IsNullOrEmpty(providerId) && !writtenProviderIds.Contains(providerKey))
                     {
-                        writer.WriteElementString(providerKey.ToLower() + "id", providerId);
+                        writer.WriteElementString(GetTagForProviderKey(providerKey), providerId);
+                        writtenProviderIds.Add(providerKey);
                     }
                 }
             }
@@ -1092,6 +1102,11 @@ namespace MediaBrowser.XbmcMetadata.Savers
                     }
                 }
             }
+        }
+
+        private static string GetTagForProviderKey(string providerKey)
+        {
+            return providerKey.ToLower() + "id";
         }
     }
 }

--- a/MediaBrowser.XbmcMetadata/Savers/EpisodeNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/EpisodeNfoSaver.cs
@@ -108,24 +108,24 @@ namespace MediaBrowser.XbmcMetadata.Savers
 
         private static readonly CultureInfo UsCulture = new CultureInfo("en-US");
 
-        protected override List<string> GetTagsUsed()
+        protected override List<string> GetTagsUsed(IHasMetadata item)
         {
-            var list = new List<string>
+            var list = base.GetTagsUsed(item);
+            list.AddRange(new string[]
             {
-                    "aired",
-                    "season",
-                    "episode",
-                    "episodenumberend",
-                    "airsafter_season",
-                    "airsbefore_episode",
-                    "airsbefore_season",
-                    "DVD_episodenumber",
-                    "DVD_season",
-                    "absolute_number",
-                    "displayseason",
-                    "displayepisode"
-            };
-
+                "aired",
+                "season",
+                "episode",
+                "episodenumberend",
+                "airsafter_season",
+                "airsbefore_episode",
+                "airsbefore_season",
+                "DVD_episodenumber",
+                "DVD_season",
+                "absolute_number",
+                "displayseason",
+                "displayepisode"
+            });
             return list;
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/MovieNfoSaver.cs
@@ -113,16 +113,16 @@ namespace MediaBrowser.XbmcMetadata.Savers
             }
         }
 
-        protected override List<string> GetTagsUsed()
+        protected override List<string> GetTagsUsed(IHasMetadata item)
         {
-            var list = new List<string>
+            var list = base.GetTagsUsed(item);
+            list.AddRange(new string[]
             {
-                    "album",
-                    "artist",
-                    "set",
-                    "id"
-            };
-
+                "album",
+                "artist",
+                "set",
+                "id"
+            });
             return list;
         }
 

--- a/MediaBrowser.XbmcMetadata/Savers/SeasonNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/SeasonNfoSaver.cs
@@ -51,11 +51,13 @@ namespace MediaBrowser.XbmcMetadata.Savers
             }
         }
 
-        protected override List<string> GetTagsUsed()
+        protected override List<string> GetTagsUsed(IHasMetadata item)
         {
-            var list = base.GetTagsUsed();
-
-            list.Add("seasonnumber");
+            var list = base.GetTagsUsed(item);
+            list.AddRange(new string[]
+            {
+                "seasonnumber"
+            });
 
             return list;
         }

--- a/MediaBrowser.XbmcMetadata/Savers/SeriesNfoSaver.cs
+++ b/MediaBrowser.XbmcMetadata/Savers/SeriesNfoSaver.cs
@@ -90,20 +90,20 @@ namespace MediaBrowser.XbmcMetadata.Savers
             }
         }
 
-        protected override List<string> GetTagsUsed()
+        protected override List<string> GetTagsUsed(IHasMetadata item)
         {
-            var list = new List<string>
+            var list = base.GetTagsUsed(item);
+            list.AddRange(new string[]
             {
-                    "id",
-                    "episodeguide",
-                    "season",
-                    "episode",
-                    "status",
-                    "airs_time",
-                    "airs_dayofweek",
-                    "animeseriesindex"
-            };
-
+                "id",
+                "episodeguide",
+                "season",
+                "episode",
+                "status",
+                "airs_time",
+                "airs_dayofweek",
+                "animeseriesindex"
+            });
             return list;
         }
 


### PR DESCRIPTION
This PR fixes the custom IExternalIds defined by my plugin being written to the .nfo file multiple times after the first save. The custom IExternalIds are added to the list returned by the TagsUsed method

When the .nfo is saved for the first time it contains the external id.
e.g.
```xml
<movie>
...
<myexternalid>1234</myexternalid>
...
<fileinfo>
...
</fileinfo>
</movie>
```

If the file is saved 3 times it ends up looking like this:
```xml
<movie>
...
<
<myexternalid>1234</myexternalid>
...
<fileinfo>
...
</fileinfo>
<myexternalid>1234</myexternalid>
<myexternalid>1234</myexternalid>
<myexternalid>1234</myexternalid>
</movie>
```


