### PR TITLE
Respect a given runtime for live tv and recordings

### DIFF
--- a/Emby.Server.Implementations/LiveTv/LiveStreamHelper.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveStreamHelper.cs
@@ -43,7 +43,7 @@ namespace Emby.Server.Implementations.LiveTv
             mediaSource.Container = info.Container;
             mediaSource.Formats = info.Formats;
             mediaSource.MediaStreams = info.MediaStreams;
-            mediaSource.RunTimeTicks = info.RunTimeTicks;
+            mediaSource.RunTimeTicks = (mediaSource.RunTimeTicks.HasValue) ? mediaSource.RunTimeTicks : info.RunTimeTicks;
             mediaSource.Size = info.Size;
             mediaSource.Timestamp = info.Timestamp;
             mediaSource.Video3DFormat = info.Video3DFormat;


### PR DESCRIPTION
If a tv backend provides this information already, than it's doing it for a good reason.
There's no reason to overwrite the runtime in such a case with one determined by ffprobe.
A particular use case is an inprogress recording with a file as input. This results in wrong durations in the players if ffprobe's RunTimeTicks are used.