### PR TITLE
Add hevc_qsv to var required

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -90,6 +90,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             var required = new[]
             {
                 "h264_qsv",
+                "hevc_qsv",
                 "mpeg2_qsv",
                 "vc1_qsv"
             };
@@ -135,6 +136,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 "srt",
                 "h264_nvenc",
                 "h264_qsv",
+                "hevc_qsv",
                 "h264_omx",
                 "h264_vaapi",
                 "ac3"


### PR DESCRIPTION
hevc_qsv should be added for letting emby recognize this de- and encoder. This could fix #2498 .