### PR TITLE
 Add hevc hw-decoders and encoders to var required

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -90,6 +90,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             var required = new[]
             {
                 "h264_qsv",
+                "hevc_qsv",
                 "mpeg2_qsv",
                 "vc1_qsv"
             };
@@ -134,9 +135,13 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 "libvorbis",
                 "srt",
                 "h264_nvenc",
+                "hevc_nvenc",
                 "h264_qsv",
+                "hevc_qsv",
                 "h264_omx",
+                "hevc_omx",
                 "h264_vaapi",
+                "hevc_vaapi",
                 "ac3"
             };
 


### PR DESCRIPTION
This hould be added for letting emby recognize this hw-decoders and encoders. This in addition to  #2506 and on the dev branch as wished.