### PR TITLE
Add user option to only include favorites in Next Up

### DIFF
--- a/Emby.Server.Implementations/TV/TVSeriesManager.cs
+++ b/Emby.Server.Implementations/TV/TVSeriesManager.cs
@@ -55,12 +55,18 @@ namespace Emby.Server.Implementations.TV
                 limit = limit.Value + 10;
             }
 
+            bool? needsFavorite = null;
+            if (user.Configuration.NextUpFavoritesOnly) {
+                needsFavorite = true;
+            }
+
             var items = _libraryManager.GetItemList(new InternalItemsQuery(user)
             {
                 IncludeItemTypes = new[] { typeof(Series).Name },
                 SortBy = new[] { ItemSortBy.SeriesDatePlayed },
                 SortOrder = SortOrder.Descending,
                 PresentationUniqueKey = presentationUniqueKey,
+                IsFavorite = needsFavorite,
                 Limit = limit,
                 ParentId = parentIdGuid,
                 Recursive = true,
@@ -107,12 +113,18 @@ namespace Emby.Server.Implementations.TV
                 limit = limit.Value + 10;
             }
 
+            bool? needsFavorite = null;
+            if (user.Configuration.NextUpFavoritesOnly) {
+                needsFavorite = true;
+            }
+
             var items = _libraryManager.GetItemList(new InternalItemsQuery(user)
             {
                 IncludeItemTypes = new[] { typeof(Series).Name },
                 SortBy = new[] { ItemSortBy.SeriesDatePlayed },
                 SortOrder = SortOrder.Descending,
                 PresentationUniqueKey = presentationUniqueKey,
+                IsFavorite = needsFavorite,
                 Limit = limit,
                 DtoOptions = new MediaBrowser.Controller.Dto.DtoOptions
                 {

--- a/MediaBrowser.Model/Configuration/UserConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/UserConfiguration.cs
@@ -44,6 +44,8 @@ namespace MediaBrowser.Model.Configuration
         public bool RememberSubtitleSelections { get; set; }
         public bool EnableNextEpisodeAutoPlay { get; set; }
 
+        public bool NextUpFavoritesOnly { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="UserConfiguration" /> class.
         /// </summary>
@@ -61,6 +63,8 @@ namespace MediaBrowser.Model.Configuration
             OrderedViews = new string[] { };
 
             GroupedFolders = new string[] { };
+
+            NextUpFavoritesOnly = false;
         }
     }
 }


### PR DESCRIPTION
This PR adds a per-user option to limit "Next Up" to favorites only. This allows a user to fine-tune what shows they see next episodes from -- it avoids things like "I started watching this show then didn't like it" from showing up in the list.

Corresponding PR to emby-web-mobile coming as well; I'm not sure how to regenerate the dist or dashboard-ui stuff, though.