### PR TITLE
MediaBrowser: Return null from GetInputFormat when in mts format.

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -184,6 +184,10 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 return null;
             }
+            if (string.Equals(container, "mts", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
 
             return container;
         }


### PR DESCRIPTION
ffmpeg does not have an '-f mts' option.  When returning mts from
GetInputFormat, that option is appended to the command arguments for
transcoding and thus ffmpeg fails with:

Unknown input format: 'MTS'

Signed-off-by: Liam R. Howlett <howlett@gmail.com>