### PR TITLE
Remove link to non-functional API documentation

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/dashboard.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/dashboard.html
@@ -151,7 +151,6 @@
                         <a href="http://emby.media" target="_blank">Emby</a>
                         <a href="http://emby.media/community" target="_blank">${LinkCommunity}</a>
                         <a href="https://github.com/MediaBrowser" target="_blank">${LinkGithub}</a>
-                        <a class="swaggerLink" target="_blank" href="#">${LinkApi}</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Until integrated API documentation (e.g. Swagger) has been restored this link should be removed as the 404 type result is disconcerting and gives the impression of a less polished product. This link, or something similar to it, can be restored once the documentation has been reimplemented.