### PR TITLE
Fix an issue causing LiveTV to stop working if a connection to a hdho…

### DIFF
--- a/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
+++ b/Emby.Server.Implementations/LiveTv/EmbyTV/EmbyTV.cs
@@ -1139,6 +1139,20 @@ namespace Emby.Server.Implementations.LiveTv.EmbyTV
 
             try
             {
+                // Remove all tuner connection which are no longer connected
+                // Iterate backward so we can modify the list as we iterate
+                for (int i = _liveStreams.Count - 1; i >= 0; i--)
+                {
+                    if (_liveStreams[i].isDisconnected())
+                    {
+                        _logger.Info("Closing live stream {0}, because it is disconnected", _liveStreams[i].OriginalStreamId);
+                        await _liveStreams[i].Close().ConfigureAwait(false);
+                        _logger.Info("Live dead stream {0} closed successfully", _liveStreams[i].OriginalStreamId);
+
+                        _liveStreams.RemoveAt(i);
+                    }
+                }
+
                 var result = _liveStreams.FirstOrDefault(i => string.Equals(i.OriginalStreamId, streamId, StringComparison.OrdinalIgnoreCase));
 
                 if (result != null && result.EnableStreamSharing)

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunHttpStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunHttpStream.cs
@@ -56,7 +56,7 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts.HdHomerun
             var taskCompletionSource = new TaskCompletionSource<bool>();
 
             StartStreaming(url, taskCompletionSource, _liveStreamCancellationTokenSource.Token);
-
+         
             //OpenedMediaSource.Protocol = MediaProtocol.File;
             //OpenedMediaSource.Path = tempFile;
             //OpenedMediaSource.ReadAtNativeFramerate = true;
@@ -130,6 +130,9 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts.HdHomerun
                     }
                     catch (Exception ex)
                     {
+                        // Flag this tunner connection as disconnected: So we don't assign more client to it
+                        _tunerConnectionLost = true;
+
                         if (isFirstAttempt)
                         {
                             _logger.ErrorException("Error opening live stream:", ex);

--- a/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunUdpStream.cs
+++ b/Emby.Server.Implementations/LiveTv/TunerHosts/HdHomerun/HdHomerunUdpStream.cs
@@ -148,6 +148,9 @@ namespace Emby.Server.Implementations.LiveTv.TunerHosts.HdHomerun
                             }
                             catch (Exception ex)
                             {
+                                // Flag this tunner connection as disconnected: So we don't assign more client to it
+                                _tunerConnectionLost = true;
+
                                 if (isFirstAttempt)
                                 {
                                     _logger.ErrorException("Error opening live stream:", ex);

--- a/MediaBrowser.Controller/LiveTv/LiveStream.cs
+++ b/MediaBrowser.Controller/LiveTv/LiveStream.cs
@@ -21,6 +21,7 @@ namespace MediaBrowser.Controller.LiveTv
         public string OriginalStreamId { get; set; }
         public bool EnableStreamSharing { get; set; }
         public string UniqueId = Guid.NewGuid().ToString("N");
+        protected bool _tunerConnectionLost = false;
 
         public List<string> SharedStreamIds = new List<string>();
         protected readonly IEnvironmentInfo Environment;
@@ -49,6 +50,11 @@ namespace MediaBrowser.Controller.LiveTv
         public virtual Task Close()
         {
             return Task.FromResult(true);
+        }
+
+        public bool isDisconnected()
+        {
+            return _tunerConnectionLost;
         }
 
         protected Stream GetInputStream(string path, long startPosition, bool allowAsyncFileRead)


### PR DESCRIPTION
Fix an issue causing LiveTV to stop working if a connection to a hdhomerun was lost.  There was no handling of connection lost causing "dead" stream to remain in the LiveStream list. Client trying to start the same channel would find the stream but ffprobe would hang because there is no data coming over the disconnected connection.

This set the connection as disconnected, and futher attempt to start a channel would first cleanup the livestream list and only use "working" tv tuner.

Note: I tried hard to find a callback path directly from the exception handling in HdHomerunHttpStream to get a pointer to the EmbyTV class, in order to remove the tuner from the _liveStream right away, but because of the way the code is structured, I had to set a flag on the tunerhost that is later checked by the EmbyTV class.  

Tested and resolve my issue with hdhomerun tuners (and Emby getting completly stuck).