### PR TITLE
Improve playback of RTSP streams

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1551,6 +1551,11 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             inputModifier += " " + GetFastSeekCommandLineParameter(state.BaseRequest);
             inputModifier = inputModifier.Trim();
+            
+            if (state.InputProtocol == MediaProtocol.Rtsp)
+            {
+                inputModifier += " -rtsp_transport tcp";
+            }
 
             if (!string.IsNullOrEmpty(state.InputAudioSync))
             {
@@ -1562,7 +1567,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 inputModifier += " -vsync " + state.InputVideoSync;
             }
 
-            if (state.ReadInputAtNativeFramerate)
+            if (state.ReadInputAtNativeFramerate && state.InputProtocol != MediaProtocol.Rtsp)
             {
                 inputModifier += " -re";
             }


### PR DESCRIPTION
Without those little changes, rtsp live tv streams get corrupted even when stream copying, but also with transcoding.
It's already really bad for sd streams, but hd streams are just unwatchable. The whole picture consists of green blocks.

Btw. this problem isn't new. It was already discussed in many posts at the time the Argus TV plugin was still alive.
These changes have the potential to fix it there also.