### PR TITLE
Update de.json

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/bower_components/emby-webcomponents/strings/de.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/bower_components/emby-webcomponents/strings/de.json
@@ -5,7 +5,7 @@
     "TV": "TV",
     "LabelDisplayMode": "Bildschirmmodus:",
     "DisplayModeHelp": "Bitte w\u00e4hle den Typ des Bildschirms auf dem Du Emby verwendest.",
-    "EnableThemeVideos": "Altiviere Titelvideos",
+    "EnableThemeVideos": "Aktiviere Titelvideos",
     "EnableThemeVideosHelp": "Wenn aktiviert, wird ein Titelvideo w\u00e4hrend dem Durchsuchen durch die Bibliothek im Hintergrund abgespielt.",
     "LabelScreensaver": "Bildschirmschoner:",
     "LabelSoundEffects": "Soundeffekte:",


### PR DESCRIPTION
Altiviere not exist in german.
The correct spelling is Aktiviere. 