### PR TITLE
Enable deinterlacing for transcoding with vaapi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,4 @@ pip-log.txt
 #Mr Developer
 .mr.developer.cfg
 MediaBrowser.WebDashboard/dashboard-ui/.idea/
+/.vs/MediaBrowser/v15/Server/sqlite3

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1369,6 +1369,11 @@ namespace MediaBrowser.Controller.MediaEncoding
                 filters.Add("hwupload");
             }
 
+            if (state.DeInterlace("h264", true) && string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
+            { 
+                filters.Add(string.Format("deinterlace_vaapi"));
+            }
+
             if (state.DeInterlace("h264", true) && !string.Equals(outputVideoCodec, "h264_vaapi", StringComparison.OrdinalIgnoreCase))
             {
                 // If it is already 60fps then it will create an output framerate that is much too high for roku and others to handle


### PR DESCRIPTION
This if clause should enable deinterlacing while transcoding with vaapi. This is very useful if Live-TV is used. At the moment the channels are just streamed interlaced if vaapi is enabled.