### PR TITLE
Adding Error Logging

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -59,7 +59,16 @@ namespace MediaBrowser.Providers.Manager
             DateTime? newDateModified = null;
             if (item.LocationType == LocationType.FileSystem)
             {
-                var file = refreshOptions.DirectoryService.GetFile(item.Path);
+                var file = null as FileSystemMetadata;
+                try
+                {
+                    file = refreshOptions.DirectoryService.GetFile(item.Path);
+                }
+                catch(Exception e)
+                {
+                    Logger.Debug("Path for {0} threw an exception!", item.Path);
+                    throw e;
+                }
                 if (file != null)
                 {
                     newDateModified = file.LastWriteTimeUtc;


### PR DESCRIPTION
If a file is named incorrectly (like a special character in the filename for example) this line can throw an error with no useful logging information to help find which file was the cause of the issue.

I would not have been able to diagnose my issue locally without this change.

Example Stacktrace w/ Change:
//This line is added
2017-12-28 12:11:25.825 Debug App: Path for T:\TV Shows\Example Show\Season 1\poorlynamedfile:?.mkv threw an exception!
//The normal output
2017-12-28 12:11:25.837 Error TaskManager: Error
	*** Error Report ***
	Version: 3.2.60.0
	Command line: C:\Users\Tim\AppData\Roaming\Emby-Server\system\EmbyServer.dll
	Operating system: Microsoft Windows NT 6.2.9200.0
	64-Bit OS: True
	64-Bit Process: True
	User Interactive: True
	Processor count: 4
	Program data path: C:\Users\Tim\AppData\Roaming\Emby-Server\programdata
	Application directory: C:\Users\Tim\AppData\Roaming\Emby-Server\system
	System.NotSupportedException: The given path's format is not supported.
	   at MediaBrowser.Providers.Manager.MetadataService`2.<RefreshMetadata>d__8.MoveNext()
	--- End of stack trace from previous location where exception was thrown ---
	   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
	   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
	   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
	   at MediaBrowser.Controller.Entities.BaseItem.<RefreshMetadata>d__351.MoveNext()
	--- End of stack trace from previous location where exception was thrown ---
	   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
	   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
	   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
	   at MediaBrowser.Controller.Entities.TV.Series.<RefreshAllMetadata>d__53.MoveNext()
	--- End of stack trace from previous location where exception was thrown ---