### PR TITLE
+ workaround for tvheadend channel icons

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -161,6 +161,15 @@ namespace MediaBrowser.Providers.Manager
 
             }).ConfigureAwait(false))
             {
+                //workaround for tvheadend channel icons
+                if (response.ContentType == "")
+                {
+                    if (response.ResponseUrl.Contains("/imagecache/"))
+                    {
+                        response.ContentType = "image/png";
+                    }
+
+                }
                 await SaveImage(item, response.Content, response.ContentType, type, imageIndex, cancellationToken).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
Set the contentType to image/png when tvheadend doesn't provide any contentType.