### PR TITLE
Fix for Intel Quicksync to respect h.264 encoding settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,5 @@ pip-log.txt
 .mr.developer.cfg
 MediaBrowser.WebDashboard/dashboard-ui/.idea/
 /.vs/MediaBrowser/v15/Server/sqlite3
+/.vs/ProjectSettings.json
+/.vs/slnx.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -234,4 +234,3 @@ pip-log.txt
 .mr.developer.cfg
 MediaBrowser.WebDashboard/dashboard-ui/.idea/
 /.vs/MediaBrowser/v15/Server/sqlite3
-

--- a/.gitignore
+++ b/.gitignore
@@ -234,5 +234,4 @@ pip-log.txt
 .mr.developer.cfg
 MediaBrowser.WebDashboard/dashboard-ui/.idea/
 /.vs/MediaBrowser/v15/Server/sqlite3
-/.vs/ProjectSettings.json
-/.vs/slnx.sqlite
+

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -638,8 +638,19 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // h264 (h264_qsv)
             else if (string.Equals(videoEncoder, "h264_qsv", StringComparison.OrdinalIgnoreCase))
-            {
-                param += "-preset 7 -look_ahead 0";
+			{
+               	string[] valid_h264_qsv = new string [] {"veryslow", "slower", "slow", "medium", "fast", "faster", "veryfast" };
+								
+				if(Array.IndexOf(valid_h264_qsv,encodingOptions.H264Preset.ToLower()) != -1)
+				{
+					param += "-preset " +  encodingOptions.H264Preset;
+				}  
+				else 
+				{		
+					param += "-preset 7";
+				}
+				
+				param += " -look_ahead 0";
 
             }
 


### PR DESCRIPTION
Luke,
Here is an fix to have intel quick sync to respect the hardware encoding settings for h264

https://emby.media/community/index.php?/topic/56730-emby-not-respecting-h264-encoding-preset-setting-on-hardware-encoding-for-intel-quick-sync/

Let me know if i need ot change anything