### PR TITLE
Addressed performance issue when dealing with large EPGs. 

### DIFF
--- a/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
+++ b/Emby.Server.Implementations/LiveTv/Listings/SchedulesDirect.cs
@@ -893,17 +893,17 @@ namespace Emby.Server.Implementations.LiveTv.Listings
                 throw new Exception("token required");
             }
 
-            var httpOptions = new HttpRequestOptions()
+            var httpOptions = new HttpRequestOptions
             {
                 Url = ApiUrl + "/lineups/" + listingsId,
                 UserAgent = UserAgent,
                 CancellationToken = cancellationToken,
                 LogErrorResponseBody = true,
                 // The data can be large so give it some extra time
-                TimeoutMs = 60000
+                TimeoutMs = 60000,
+                RequestHeaders = { ["token"] = token }
             };
 
-            httpOptions.RequestHeaders["token"] = token;
 
             var list = new List<ChannelInfo>();
 

--- a/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
+++ b/Emby.Server.Implementations/LiveTv/LiveTvManager.cs
@@ -3048,7 +3048,8 @@ namespace Emby.Server.Implementations.LiveTv
                 result.Name = tunerChannel.Number + " " + result.Name;
             }
 
-            var providerChannel = EmbyTV.EmbyTV.Current.GetEpgChannelFromTunerChannel(mappings, tunerChannel, epgChannels);
+            var channelInfoDictionaries = new ChannelInfoDictionaries(epgChannels);
+            var providerChannel = EmbyTV.EmbyTV.Current.GetEpgChannelFromTunerChannel(mappings, tunerChannel, channelInfoDictionaries);
 
             if (providerChannel != null)
             {

--- a/MediaBrowser.Controller/LiveTv/ChannelInfoDictionaries.cs
+++ b/MediaBrowser.Controller/LiveTv/ChannelInfoDictionaries.cs
@@ -1,0 +1,62 @@
+﻿namespace MediaBrowser.Controller.LiveTv
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class ChannelInfoDictionaries
+    {
+        private readonly Lazy<IDictionary<string, ChannelInfo>> _lazyChannelsByName;
+
+        private readonly Lazy<IDictionary<string, ChannelInfo>> _lazyChannelsById;
+
+        private readonly Lazy<IDictionary<string, ChannelInfo>> _lazyChannelsByNumber;
+
+        public ChannelInfoDictionaries(List<ChannelInfo> channelInfos)
+        {
+            _lazyChannelsByName = new Lazy<IDictionary<string, ChannelInfo>>(
+                () =>
+                {
+                    var dictionary = new Dictionary<string, ChannelInfo>();
+                    foreach (var channelInfo in channelInfos)
+                    {
+                        dictionary[channelInfo.Name?.ToUpper() ?? string.Empty] = channelInfo;
+                    }
+
+                    return dictionary;
+                });
+            _lazyChannelsById = new Lazy<IDictionary<string, ChannelInfo>>(
+                () =>
+                {
+                    var dictionary = new Dictionary<string, ChannelInfo>();
+                    foreach (var channelInfo in channelInfos)
+                    {
+                        dictionary[channelInfo.Id?.ToUpper() ?? string.Empty] = channelInfo;
+                    }
+
+                    return dictionary;
+                });
+            _lazyChannelsByNumber = new Lazy<IDictionary<string, ChannelInfo>>(
+                () =>
+                {
+                    var dictionary = new Dictionary<string, ChannelInfo>();
+                    foreach (var channelInfo in channelInfos)
+                    {
+                        dictionary[NormalizeName(channelInfo.Name?.ToUpper() ?? string.Empty)] = channelInfo;
+                    }
+
+                    return dictionary;
+                });
+        }
+
+        public IDictionary<string, ChannelInfo> ChannelsByName => _lazyChannelsByName.Value;
+
+        public IDictionary<string, ChannelInfo> ChannelsById => _lazyChannelsById.Value;
+
+        public IDictionary<string, ChannelInfo> ChannelsByNumber => _lazyChannelsByNumber.Value;
+
+        private static string NormalizeName(string value)
+        {
+            return value.Replace(" ", string.Empty).Replace("-", string.Empty);
+        }
+    }
+}

--- a/MediaBrowser.Controller/MediaBrowser.Controller.csproj
+++ b/MediaBrowser.Controller/MediaBrowser.Controller.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Library\NameExtensions.cs" />
     <Compile Include="Library\PlaybackStopEventArgs.cs" />
     <Compile Include="Library\UserDataSaveEventArgs.cs" />
+    <Compile Include="LiveTv\ChannelInfoDictionaries.cs" />
     <Compile Include="LiveTv\IListingsProvider.cs" />
     <Compile Include="LiveTv\ITunerHost.cs" />
     <Compile Include="LiveTv\RecordingGroup.cs" />


### PR DESCRIPTION
When refreshing the guide, a List<ChannelInfo> would get built and then queried using .FirstOrDefault(), which is slow with large lists.  

A dictionary lookup is significantly quicker, with a small trade off being that we create 3 dictionaries to act like indexes for our data, one based on ChannelInfo.Id, another based on ChannelInfo.Name, and finally ChannelInfo.Number.  If you have a large M3U playlist (8000 or so entries), as well as large EPG data (14+ MB), the call to FirstOrDefault would get called repeatedly which causes the list to be scanned multiple times, along with calling a function for every time to format the string, or performing a case insensitive search.

To get around the case insensitivity with the dictionary, all the keys have been made to UPPERCASE so that it will match.

There's still room for improvement but now the guide will refresh in a more reasonable time.  Before this fix, I left it running overnight and it was only 16% complete.  