### PR TITLE
Bugfix: Incorrect use of DateTime.ToUniversalTime() results in incorrect dates returned by metadata providers

### DIFF
--- a/Emby.Server.Implementations/HttpServer/HttpResultFactory.cs
+++ b/Emby.Server.Implementations/HttpServer/HttpResultFactory.cs
@@ -702,7 +702,7 @@ namespace Emby.Server.Implementations.HttpServer
 
                 if (DateTime.TryParse(ifModifiedSinceHeader, out ifModifiedSince))
                 {
-                    if (IsNotModified(ifModifiedSince.ToUniversalTime(), cacheDuration, lastDateModified))
+                    if (IsNotModified(ifModifiedSince, cacheDuration, lastDateModified))
                     {
                         return true;
                     }

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -47,6 +47,7 @@ using MediaBrowser.Model.Tasks;
 using Emby.Server.Implementations.Playlists;
 using MediaBrowser.Providers.MediaInfo;
 using MediaBrowser.Controller;
+using MediaBrowser.Providers.Manager;
 
 namespace Emby.Server.Implementations.Library
 {
@@ -2456,7 +2457,8 @@ namespace Emby.Server.Implementations.Library
                 {
                     if (episodeInfo.Year.HasValue && episodeInfo.Month.HasValue && episodeInfo.Day.HasValue)
                     {
-                        episode.PremiereDate = new DateTime(episodeInfo.Year.Value, episodeInfo.Month.Value, episodeInfo.Day.Value).ToUniversalTime();
+                        var infoDate = new DateTime(episodeInfo.Year.Value, episodeInfo.Month.Value, episodeInfo.Day.Value);
+                        episode.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(infoDate, ProviderUtils.GetUsEasternTimeZoneInfo());
                     }
 
                     if (episode.PremiereDate.HasValue)

--- a/MediaBrowser.Api/UserLibrary/ItemsService.cs
+++ b/MediaBrowser.Api/UserLibrary/ItemsService.cs
@@ -357,6 +357,7 @@ namespace MediaBrowser.Api.UserLibrary
 
             if (!string.IsNullOrEmpty(request.MinDateLastSaved))
             {
+                // Check this!!!!!!
                 query.MinDateLastSaved = DateTime.Parse(request.MinDateLastSaved, null, DateTimeStyles.RoundtripKind).ToUniversalTime();
             }
 

--- a/MediaBrowser.Providers/Manager/ProviderUtils.cs
+++ b/MediaBrowser.Providers/Manager/ProviderUtils.cs
@@ -206,6 +206,39 @@ namespace MediaBrowser.Providers.Manager
             }
         }
 
+        public static TimeZoneInfo GetUsEasternTimeZoneInfo()
+        {
+            TimeZoneInfo easternZone = null;
+
+            try
+            {
+                // Windows
+                easternZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            }
+            catch (TimeZoneNotFoundException)
+            {
+            }
+
+            if (easternZone == null)
+            {
+                try
+                {
+                    // Mono/Linux
+                    easternZone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+                }
+                catch (TimeZoneNotFoundException)
+                {
+                }
+            }
+
+            if (easternZone == null)
+            {
+                easternZone = TimeZoneInfo.CreateCustomTimeZone("Custom_EST", TimeSpan.FromHours(-5), "Custom_EST", "Custom_EST");
+            }
+
+            return easternZone;
+        }
+
         private static void MergePeople(List<PersonInfo> source, List<PersonInfo> target)
         {
             foreach (var person in target)

--- a/MediaBrowser.Providers/Movies/GenericMovieDbInfo.cs
+++ b/MediaBrowser.Providers/Movies/GenericMovieDbInfo.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Extensions;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.Movies
 {
@@ -203,7 +204,7 @@ namespace MediaBrowser.Providers.Movies
                 // These dates are always in this exact format
                 if (DateTime.TryParse(movieData.release_date, _usCulture, DateTimeStyles.None, out r))
                 {
-                    movie.PremiereDate = r.ToUniversalTime();
+                    movie.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(r, ProviderUtils.GetUsEasternTimeZoneInfo());
                     movie.ProductionYear = movie.PremiereDate.Value.Year;
                 }
             }

--- a/MediaBrowser.Providers/Movies/MovieDbProvider.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbProvider.cs
@@ -23,6 +23,7 @@ using MediaBrowser.Controller.IO;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Net;
 using MediaBrowser.Model.Extensions;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.Movies
 {
@@ -94,7 +95,7 @@ namespace MediaBrowser.Providers.Movies
                     // These dates are always in this exact format
                     if (DateTime.TryParse(obj.release_date, _usCulture, DateTimeStyles.None, out r))
                     {
-                        remoteResult.PremiereDate = r.ToUniversalTime();
+                        remoteResult.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(r, ProviderUtils.GetUsEasternTimeZoneInfo());
                         remoteResult.ProductionYear = remoteResult.PremiereDate.Value.Year;
                     }
                 }

--- a/MediaBrowser.Providers/Movies/MovieDbSearch.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbSearch.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.Movies
 {
@@ -185,7 +186,7 @@ namespace MediaBrowser.Providers.Movies
                             // These dates are always in this exact format
                             if (DateTime.TryParseExact(i.release_date, "yyyy-MM-dd", EnUs, DateTimeStyles.None, out r))
                                 {
-                                    remoteResult.PremiereDate = r.ToUniversalTime();
+                                    remoteResult.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(r, ProviderUtils.GetUsEasternTimeZoneInfo());
                                     remoteResult.ProductionYear = remoteResult.PremiereDate.Value.Year;
                                 }
                             }
@@ -240,7 +241,7 @@ namespace MediaBrowser.Providers.Movies
                             // These dates are always in this exact format
                             if (DateTime.TryParseExact(i.first_air_date, "yyyy-MM-dd", EnUs, DateTimeStyles.None, out r))
                                 {
-                                    remoteResult.PremiereDate = r.ToUniversalTime();
+                                    remoteResult.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(r, ProviderUtils.GetUsEasternTimeZoneInfo());
                                     remoteResult.ProductionYear = remoteResult.PremiereDate.Value.Year;
                                 }
                             }

--- a/MediaBrowser.Providers/People/MovieDbPersonProvider.cs
+++ b/MediaBrowser.Providers/People/MovieDbPersonProvider.cs
@@ -21,6 +21,7 @@ using MediaBrowser.Controller.IO;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Logging;
 using MediaBrowser.Model.Net;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.People
 {
@@ -176,12 +177,12 @@ namespace MediaBrowser.Providers.People
 
                 if (DateTime.TryParseExact(info.birthday, "yyyy-MM-dd", new CultureInfo("en-US"), DateTimeStyles.None, out date))
                 {
-                    item.PremiereDate = date.ToUniversalTime();
+                    item.PremiereDate = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
                 }
 
                 if (DateTime.TryParseExact(info.deathday, "yyyy-MM-dd", new CultureInfo("en-US"), DateTimeStyles.None, out date))
                 {
-                    item.EndDate = date.ToUniversalTime();
+                    item.EndDate = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
                 }
 
                 item.SetProviderId(MetadataProviders.Tmdb, info.id.ToString(_usCulture));

--- a/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/MissingEpisodeProvider.cs
@@ -19,6 +19,7 @@ using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Xml;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.TV
 {
@@ -511,7 +512,7 @@ namespace MediaBrowser.Providers.TV
                                                 DateTime date;
                                                 if (DateTime.TryParse(val, out date))
                                                 {
-                                                    airDate = date.ToUniversalTime();
+                                                    TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
                                                 }
                                             }
 

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbEpisodeProvider.cs
@@ -20,6 +20,7 @@ using System.Xml;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Xml;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.TV
 {
@@ -411,7 +412,7 @@ namespace MediaBrowser.Providers.TV
                                             DateTime date;
                                             if (DateTime.TryParse(val, out date))
                                             {
-                                                date = date.ToUniversalTime();
+                                                date = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
 
                                                 return date;
                                             }
@@ -675,7 +676,7 @@ namespace MediaBrowser.Providers.TV
                                         DateTime date;
                                         if (DateTime.TryParse(val, out date))
                                         {
-                                            date = date.ToUniversalTime();
+                                            date = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
 
                                             item.PremiereDate = date;
                                             item.ProductionYear = date.Year;

--- a/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/TheTVDB/TvdbSeriesProvider.cs
@@ -22,6 +22,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Xml;
+using MediaBrowser.Providers.Manager;
 
 namespace MediaBrowser.Providers.TV
 {
@@ -929,7 +930,7 @@ namespace MediaBrowser.Providers.TV
                                     DateTime date;
                                     if (DateTime.TryParse(val, out date))
                                     {
-                                        airDate = date.ToUniversalTime();
+                                        airDate = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
                                     }
                                 }
 
@@ -1271,7 +1272,7 @@ namespace MediaBrowser.Providers.TV
                                     DateTime date;
                                     if (DateTime.TryParse(val, out date))
                                     {
-                                        date = date.ToUniversalTime();
+                                        date = TimeZoneInfo.ConvertTimeToUtc(date, ProviderUtils.GetUsEasternTimeZoneInfo());
 
                                         item.PremiereDate = date;
                                         item.ProductionYear = date.Year;


### PR DESCRIPTION
Accidentially I've seen that this issue is still unresolved.

Here's an updated version of my 2years old PR. I still think that this is the right (small) solution unless we want to introduce default Read- and Write-Configurations (== time zone +  datetime format) for all providers

https://emby.media/community/index.php?/topic/26050-premiered-date-is-showing-up-wrong/page-7#entry595893

Here's the original description:

This is a revised approach to fix the problems caused by incorrect
timezone adjustments.

- Let's look at MovieDbProvider, Line 97
- DateTime.TryParse creates a date from the string in the xml

- The next statement ".ToUniversalTime()" converts the datetime from
local a local datetime to a UTC datetime

- Emby-Server1 is in Timezone UTC+3: If the parsed date is "2016-03-30
01:00" the converted date would be "2016-03-29 22:00"
- Emby-Server2 is in Timezone UTC-9: If the parsed date is "2016-03-30
01:00" the converted date would be "2016-03-30 10:00"

As a result, Emby-Server1 would store a different item date than
Emby-Server2. This is incorrect because the UTC date (per definition)
must be a constant value that is independent of any time zone.

The previous pull request suggested to remove all UTC conversions but
was turned down because it would break consistency of the API.
This commit follows a different approach: It assumes a constant timezone
(US EST - Eastern Standard Time) for all dates returned from the
affected metadata providers.
The result: Emby will continue to use UTC based dates, but the
conversion is done consistently.