### PR TITLE
Fix german translation for 'remember me'

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/strings/de.json
+++ b/MediaBrowser.WebDashboard/dashboard-ui/strings/de.json
@@ -1691,7 +1691,7 @@
     "EnablePhotosHelp": "Fotos werden erkannt und neben anderen Mediendateien angezeigt.",
     "SyncToOtherDevices": "Mit anderen Ger\u00e4ten synchronisieren",
     "ManageOfflineDownloads": "Offline-Downloads verwalten",
-    "RememberMe": "Erinnere mich",
+    "RememberMe": "Angemeldet bleiben",
     "HeaderOfflineSync": "Offline-Synchronisierung",
     "LabelMaxAudioFileBitrate": "Max. Bitrate Audio-Datei:",
     "LabelMaxAudioFileBitrateHelp": "Audio-Dateien mit einer h\u00f6heren Bitrate werden durch den Emby-server konvertiert. W\u00e4hle f\u00fcr eine bessere Qualit\u00e4t einen h\u00f6heren Wert aus, um Speicherplatz zu sparen einen niedrigeren.",


### PR DESCRIPTION
'Remember me' on the login page was translated in german to 'Erinnere mich' which actually means 'Remind me'. The literal translation for this would be 'Erinnere dich an mich' which would be a bad expression given this context. In german usually the frase 'Angemeldet bleiben' is used, which literally means 'Stay logged in'.